### PR TITLE
Button to jump to source

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -188,6 +188,11 @@
         "icon": "$(output)"
       },
       {
+        "command": "bitswan.jumpToSource",
+        "title": "Jump to Source",
+        "icon": "$(go-to-file)"
+      },
+      {
         "command": "bitswan.showImageLogs",
         "title": "Show Logs",
         "icon": "$(output)"
@@ -264,6 +269,11 @@
           "command": "bitswan.showAutomationLogs",
           "when": "view == bitswan-automations && viewItem =~ /^automation,active/",
           "group": "inline@5"
+        },
+        {
+          "command": "bitswan.jumpToSource",
+          "when": "view == bitswan-automations && viewItem =~ /^automation,/",
+          "group": "inline@6"
         },
         {
           "command": "bitswan.showImageLogs",

--- a/Extension/src/commands/automations.ts
+++ b/Extension/src/commands/automations.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { AutomationItem } from '../views/automations_view';
 import { getAutomationLogs, getAutomations } from '../lib';
 import { AutomationsViewProvider } from '../views/automations_view';
@@ -16,4 +17,27 @@ export async function refreshAutomationsCommand(context: vscode.ExtensionContext
         entityType: 'automation',
         getItemsFunction: getAutomations
     });
+}
+
+export async function jumpToSourceCommand(context: vscode.ExtensionContext, automationItem: AutomationItem) {
+    if (automationItem.relativePath) {
+        let targetPath = automationItem.relativePath;
+
+        // If the path is relative, resolve it against the workspace root
+        if (!path.isAbsolute(targetPath)) {
+            const workspaceFolders = vscode.workspace.workspaceFolders;
+            if (workspaceFolders) {
+                targetPath = path.join(workspaceFolders[0].uri.fsPath, targetPath);
+            }
+        }
+        
+        const uri = vscode.Uri.file(targetPath);
+        try {
+            await vscode.commands.executeCommand('revealInExplorer', uri);
+            return;
+        } catch (error) {
+            vscode.window.showErrorMessage(`Could not reveal folder in Explorer`);
+            return;
+        }
+    }
 }

--- a/Extension/src/commands/deployments.ts
+++ b/Extension/src/commands/deployments.ts
@@ -81,6 +81,12 @@ export async function deployCommandAbstract(context: vscode.ExtensionContext, fo
                 contentType: 'application/zip',
             });
 
+            // Send relative path
+            if (itemSet === "automations") {
+                const relativePath = path.relative(workspaceFolders[0].uri.fsPath, folderPath);
+                form.append('relative_path', relativePath);
+            }
+
             progress.report({ increment: 50, message: "Uploading to server " + deployUrl.toString() });
 
             const success = await deploy(deployUrl.toString(), form, details.deploySecret);

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -169,6 +169,9 @@ export function activate(context: vscode.ExtensionContext) {
     let showAutomationLogsCommand = vscode.commands.registerCommand('bitswan.showAutomationLogs', 
         async (item: AutomationItem) => automationCommands.showAutomationLogsCommand(context, automationsProvider, item));
 
+    let jumpToSourceCommand = vscode.commands.registerCommand('bitswan.jumpToSource', 
+        async (item: AutomationItem) => automationCommands.jumpToSourceCommand(context, item));
+
     let showImageLogsCommand = vscode.commands.registerCommand('bitswan.showImageLogs', 
         async (item: ImageItem) => imageCommands.showImageLogsCommand(context, imagesProvider, item));
 
@@ -244,6 +247,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(deactivateAutomationCommand);
     context.subscriptions.push(deleteAutomationCommand);
     context.subscriptions.push(deleteImageCommand);
+    context.subscriptions.push(jumpToSourceCommand);
 
     // Refresh the tree views when files change in the workspace
     const watcher = vscode.workspace.createFileSystemWatcher('**/*');

--- a/Extension/src/lib.ts
+++ b/Extension/src/lib.ts
@@ -82,6 +82,7 @@ export const getAutomations = async (
     automations.forEach((a) => {
       a.deploymentId = a.deployment_id;
       a.automationUrl = a.automation_url;
+      a.relativePath = a.relative_path;
     });
     return automations;
   } else {

--- a/Extension/src/views/automations_view.ts
+++ b/Extension/src/views/automations_view.ts
@@ -32,7 +32,8 @@ export class AutomationsViewProvider implements vscode.TreeDataProvider<vscode.T
                 automation.status,
                 automation.deploymentId,
                 automation.active,
-                automation.automationUrl
+                automation.automationUrl,
+                automation.relativePath
             )
         );
 
@@ -58,7 +59,8 @@ export class AutomationItem extends vscode.TreeItem {
         public readonly status: string,
         public readonly deploymentId: string,
         public readonly active: boolean = false,
-        public readonly automationUrl: string
+        public readonly automationUrl: string,
+        public readonly relativePath: string
     ) {
         super(name, vscode.TreeItemCollapsibleState.None);
         this.tooltip = `${this.name}`;


### PR DESCRIPTION
This pull request introduces a new "Jump to Source" feature for automation items in the VS Code extension. The changes include adding a new command, updating the automation model to include relative paths, and integrating the feature into the extension's UI and backend.

### New Feature: "Jump to Source" Command
* Added a new command `bitswan.jumpToSource` in `package.json` with an icon and title, and integrated it into the inline context menu for automation items. [[1]](diffhunk://#diff-62bdf835c36931e2307d4d55bb2f11bcfef5e8dc5714ef35b7d5ae81bc5a10bcR190-R194) [[2]](diffhunk://#diff-62bdf835c36931e2307d4d55bb2f11bcfef5e8dc5714ef35b7d5ae81bc5a10bcR273-R277)
* Implemented the `jumpToSourceCommand` function in `automations.ts` to resolve relative paths and open the corresponding file or folder in the Explorer.
* Registered the `bitswan.jumpToSource` command in `extension.ts` and ensured it is properly disposed of during deactivation. [[1]](diffhunk://#diff-0e7f90442eb92efafe9abe750e33f60f9a1919d65903912a15fadd514bb0622bR172-R174) [[2]](diffhunk://#diff-0e7f90442eb92efafe9abe750e33f60f9a1919d65903912a15fadd514bb0622bR250)

### Backend Enhancements
* Updated the automation model in `lib.ts` to include the `relativePath` property from the backend response.
* Modified `AutomationsViewProvider` and `AutomationItem` classes to handle the new `relativePath` property, enabling the "Jump to Source" functionality. [[1]](diffhunk://#diff-9eb76a564425f543b0331de20028801c600e89fd6ccb66b62392036c8fcbd001L35-R36) [[2]](diffhunk://#diff-9eb76a564425f543b0331de20028801c600e89fd6ccb66b62392036c8fcbd001L61-R63)

### Deployment Adjustments
* Enhanced the deployment command in `deployments.ts` to send the relative path of automation files during deployment.