### PR TITLE
Switch to tar.gz and send structured deploy components

### DIFF
--- a/Extension/src/commands/deployments.ts
+++ b/Extension/src/commands/deployments.ts
@@ -237,7 +237,7 @@ export async function deployCommandAbstract(
                 // Deploy to dev stage with -dev suffix
                 const devDeployUrl = urlJoin(details.deployUrl, "automations", devDeploymentId, "deploy").toString();
                 const deployedBy = await getUserEmail(context);
-                const deployResult = await promoteAutomation(devDeployUrl, details.deploySecret, checksum, 'dev', relativePath, undefined, undefined, deployedBy);
+                const deployResult = await promoteAutomation(devDeployUrl, details.deploySecret, checksum, 'dev', relativePath, undefined, undefined, deployedBy, normalizedFolderName, devBpName);
 
                 if (deployResult.alreadyDeploying) {
                     vscode.window.showWarningMessage(`Deployment ${devDeploymentId} is already in progress`);

--- a/Extension/src/commands/promotions.ts
+++ b/Extension/src/commands/promotions.ts
@@ -71,7 +71,7 @@ export async function promoteStageCommand(
 
             const deployUrl = urlJoin(details.deployUrl, "automations", targetDeploymentId, "deploy").toString();
             const deployedBy = await getUserEmail(context);
-            const deployResult = await promoteAutomation(deployUrl, details.deploySecret, checksum, targetStage, undefined, undefined, undefined, deployedBy);
+            const deployResult = await promoteAutomation(deployUrl, details.deploySecret, checksum, targetStage, undefined, undefined, undefined, deployedBy, sanitizedSourceName, sanitizedBpName);
 
             if (deployResult.alreadyDeploying) {
                 vscode.window.showWarningMessage(`Deployment ${targetDeploymentId} is already in progress`);
@@ -224,14 +224,14 @@ export async function openPromotionManagerCommand(
         async (message) => {
             switch (message.command) {
                 case 'promote':
-                    await handlePromote(message.fromStage, message.toStage, message.checksum, details, deploymentIds, sanitizedSourceName, context);
+                    await handlePromote(message.fromStage, message.toStage, message.checksum, details, deploymentIds, sanitizedSourceName, pmSanitizedBp, context);
                     await updateWebview();
                     break;
                 case 'showLogs':
                     await handleShowLogs(message.deploymentId, details, context);
                     break;
                 case 'rollback':
-                    await handleRollback(message.checksum, message.stage, message.replicas, details, deploymentIds, sanitizedSourceName, context);
+                    await handleRollback(message.checksum, message.stage, message.replicas, details, deploymentIds, sanitizedSourceName, pmSanitizedBp, context);
                     await updateWebview();
                     break;
                 case 'scale':
@@ -273,6 +273,7 @@ async function handlePromote(
     details: { deployUrl: string; deploySecret: string },
     deploymentIds: { dev: string; staging: string; production: string },
     sanitizedSourceName: string,
+    sanitizedBpName: string,
     context: vscode.ExtensionContext
 ) {
     const fromDeploymentId = deploymentIds[fromStage as keyof typeof deploymentIds];
@@ -308,7 +309,7 @@ async function handlePromote(
             try {
                 progress.report({ increment: 50, message: `Promoting to ${toStage}...` });
                 const deployedBy = await getUserEmail(context);
-                const deployResult = await promoteAutomation(deployUrl, details.deploySecret, checksum!, toStage, undefined, undefined, undefined, deployedBy);
+                const deployResult = await promoteAutomation(deployUrl, details.deploySecret, checksum!, toStage, undefined, undefined, undefined, deployedBy, sanitizedSourceName, sanitizedBpName);
 
                 if (deployResult.alreadyDeploying) {
                     vscode.window.showWarningMessage(`Deployment ${toDeploymentId} is already in progress`);
@@ -381,6 +382,7 @@ async function handleRollback(
     details: { deployUrl: string; deploySecret: string },
     deploymentIds: { dev: string; staging: string; production: string },
     sanitizedSourceName: string,
+    sanitizedBpName: string,
     context: vscode.ExtensionContext
 ) {
     const deploymentId = stage === 'production' || !stage ? sanitizedSourceName : deploymentIds[stage as keyof typeof deploymentIds];
@@ -405,7 +407,7 @@ async function handleRollback(
                 const deployedBy = await getUserEmail(context);
                 const deployResult = await promoteAutomation(
                     deployUrl, details.deploySecret, checksum, normalizedStage,
-                    undefined, undefined, replicas, deployedBy
+                    undefined, undefined, replicas, deployedBy, sanitizedSourceName, sanitizedBpName
                 );
 
                 if (deployResult.alreadyDeploying) {

--- a/Extension/src/lib.ts
+++ b/Extension/src/lib.ts
@@ -1297,6 +1297,8 @@ export const promoteAutomation = async (
   automationConfig?: AutomationConfigParams,
   replicas?: number,
   deployedBy?: string,
+  automationName?: string,
+  context?: string,
 ): Promise<DeployResponse> => {
   const form = new FormData();
   form.append('checksum', checksum);
@@ -1309,6 +1311,12 @@ export const promoteAutomation = async (
   }
   if (deployedBy) {
     form.append('deployed_by', deployedBy);
+  }
+  if (automationName) {
+    form.append('automation_name', automationName);
+  }
+  if (context) {
+    form.append('context', context);
   }
   // Send automation config for live-dev (so server doesn't need to read from filesystem)
   if (automationConfig) {


### PR DESCRIPTION
## Summary
Two changes bundled:

1. **tar.gz instead of zip** for all asset uploads/downloads:
   - `createStreamingArchive()` replaces `createStreamingZip()` using `archiver('tar', { gzip: true })`
   - Upload content type: `application/gzip`
   - Asset download extraction uses `tar xzf` instead of JSZip
   - Image uploads use tar.gz

2. **Send automation_name/context** in all promote/deploy/rollback calls so the server can build correct URL templates

Depends on bitswan-space/bitswan-gitops#162

## Test plan
- [ ] Deploy an automation, verify tar.gz upload works
- [ ] Promote dev → staging, verify context hash in URL template
- [ ] Download/checkout an asset version

🤖 Generated with [Claude Code](https://claude.com/claude-code)