### PR TITLE
Remove Copilot extensions from editor image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ ENV ELECTRON_NO_ATTACH_CONSOLE=1
 ENV VSCODE_DISABLE_CRASH_REPORTER=1
 ENV PYTHON_EXTENSION_VERSION="2025.17.2025100201"
 ENV JUPYTER_EXTENSION_VERSION="2025.8.0"
-ENV COPILOT_EXTENSION_VERSION="1.378.1798"
-ENV COPILOT_CHAT_EXTENSION_VERSION="0.31.4"
 ENV PYLANCE_EXTENSION_VERSION="2025.8.3"
 
 USER root
@@ -95,12 +93,6 @@ RUN mkdir -p /home/coder/.local/share/code-server/extensions
 RUN mkdir -p /opt/extensions
 RUN chown -R coder:coder /home/coder/.local/share/code-server
 RUN chown -R coder:coder /opt/extensions
-
-RUN curl -L -o /opt/extensions/copilot.vsix.gz "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/GitHub/vsextensions/copilot/$COPILOT_EXTENSION_VERSION/vspackage" && \
-    gunzip /opt/extensions/copilot.vsix.gz
-
-RUN curl -L -o /opt/extensions/copilot-chat.vsix.gz "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/GitHub/vsextensions/copilot-chat/$COPILOT_CHAT_EXTENSION_VERSION/vspackage" && \
-    gunzip /opt/extensions/copilot-chat.vsix.gz
 
 RUN curl -L -o /opt/extensions/pylance.vsix.gz "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-python/vsextensions/vscode-pylance/$PYLANCE_EXTENSION_VERSION/vspackage" && \
     gunzip /opt/extensions/pylance.vsix.gz

--- a/update-entrypoint.sh
+++ b/update-entrypoint.sh
@@ -210,8 +210,6 @@ track_installation() {
 }
 
 # Install marketplace extensions from pre-downloaded files
-install_or_update_extension_local "GitHub.copilot" "$COPILOT_EXTENSION_VERSION" "/opt/extensions/copilot.vsix"
-install_or_update_extension_local "GitHub.copilot-chat" "$COPILOT_CHAT_EXTENSION_VERSION" "/opt/extensions/copilot-chat.vsix"
 install_or_update_extension_local "ms-python.vscode-pylance" "$PYLANCE_EXTENSION_VERSION" "/opt/extensions/pylance.vsix"
 install_or_update_extension_local "ms-python.python" "$PYTHON_EXTENSION_VERSION" "/opt/extensions/python.vsix"
 install_or_update_extension_local "ms-toolsai.jupyter" "$JUPYTER_EXTENSION_VERSION" "/opt/extensions/jupyter.vsix"


### PR DESCRIPTION
## Summary
Remove GitHub Copilot and Copilot Chat from the editor Docker image. Copilot is now opt-in via `bitswan workspace service editor install-copilot`.

- Remove `COPILOT_EXTENSION_VERSION` and `COPILOT_CHAT_EXTENSION_VERSION` env vars
- Remove vsix download steps from Dockerfile
- Remove entrypoint installation calls

## Test plan
- [ ] Build editor image — no Copilot download
- [ ] Start editor — Copilot not installed
- [ ] Run install-copilot CLI command — Copilot installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)