### PR TITLE
Add Remove All Orphaned action on Other section

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -241,6 +241,11 @@
         "icon": "$(terminal-kill)"
       },
       {
+        "command": "bitswan.removeAllOrphaned",
+        "title": "Remove All Orphaned",
+        "icon": "$(trash)"
+      },
+      {
         "command": "bitswan.stopAutomation",
         "title": "Stop Automation",
         "icon": "$(debug-stop)"
@@ -514,6 +519,11 @@
           "command": "bitswan.deleteAutomation",
           "when": "view == bitswan-unified-business-processes && viewItem =~ /^automation,/",
           "group": "inline@4"
+        },
+        {
+          "command": "bitswan.removeAllOrphaned",
+          "when": "view == bitswan-unified-business-processes && viewItem == otherAutomations",
+          "group": "inline"
         },
         {
           "command": "bitswan.restartAutomation",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -523,7 +523,7 @@
         {
           "command": "bitswan.removeAllOrphaned",
           "when": "view == bitswan-unified-business-processes && viewItem == otherAutomations",
-          "group": "inline"
+          "group": "7_modification"
         },
         {
           "command": "bitswan.restartAutomation",

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -730,20 +730,19 @@ export function activate(context: vscode.ExtensionContext) {
             const details = await getDeployDetails(context);
             if (!details) { return; }
 
-            const automations = context.globalState.get<any[]>('automations', []);
-            // Collect all orphaned automation items from the "Other" section
-            const children = await automationsProvider.getChildren(item);
-            const orphanedItems = (children || []).filter(
+            // Get orphaned items from the unified view provider
+            const children = await unifiedBusinessProcessesProvider.getChildren(item);
+            const orphaned = (children || []).filter(
                 (child): child is AutomationItem => child instanceof AutomationItem
             );
 
-            if (orphanedItems.length === 0) {
+            if (orphaned.length === 0) {
                 vscode.window.showInformationMessage('No orphaned automations to remove.');
                 return;
             }
 
             const confirm = await vscode.window.showWarningMessage(
-                `Remove ${orphanedItems.length} orphaned automation(s)?`,
+                `Remove ${orphaned.length} orphaned automation(s)?`,
                 { modal: true },
                 'Remove All'
             );
@@ -756,12 +755,12 @@ export function activate(context: vscode.ExtensionContext) {
                 title: 'Removing orphaned automations',
                 cancellable: false,
             }, async (progress) => {
-                for (const orphan of orphanedItems) {
+                for (const orphan of orphaned) {
                     try {
                         const url = `${details.deployUrl}/automations/${orphan.deploymentId}`;
                         await deleteAutomation(url, details.deploySecret);
                         removed++;
-                        progress.report({ message: `${removed}/${orphanedItems.length}` });
+                        progress.report({ message: `${removed}/${orphaned.length}` });
                     } catch {
                         failed++;
                     }

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -5,7 +5,7 @@ import { AutomationItem } from './views/automations_view';
 import { ImageItem } from './views/unified_images_view';
 import { FolderItem } from './views/sources_view';
 import { GitOpsItem } from './views/workspaces_view';
-import { BusinessProcessItem, AutomationSourceFileItem } from './views/unified_business_processes_view';
+import { BusinessProcessItem, AutomationSourceFileItem, OtherAutomationsItem } from './views/unified_business_processes_view';
 import { AutomationSourceItem, StageItem } from './views/unified_business_processes_view';
 
 // Import commands from the new command modules
@@ -725,6 +725,57 @@ export function activate(context: vscode.ExtensionContext) {
             })(context, automationsProvider, automationItem);
         });
 
+    let removeAllOrphanedCommand = vscode.commands.registerCommand('bitswan.removeAllOrphaned',
+        async (item: OtherAutomationsItem) => {
+            const details = await getDeployDetails(context);
+            if (!details) { return; }
+
+            const automations = context.globalState.get<any[]>('automations', []);
+            // Collect all orphaned automation items from the "Other" section
+            const children = await automationsProvider.getChildren(item);
+            const orphanedItems = (children || []).filter(
+                (child): child is AutomationItem => child instanceof AutomationItem
+            );
+
+            if (orphanedItems.length === 0) {
+                vscode.window.showInformationMessage('No orphaned automations to remove.');
+                return;
+            }
+
+            const confirm = await vscode.window.showWarningMessage(
+                `Remove ${orphanedItems.length} orphaned automation(s)?`,
+                { modal: true },
+                'Remove All'
+            );
+            if (confirm !== 'Remove All') { return; }
+
+            let removed = 0;
+            let failed = 0;
+            await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Notification,
+                title: 'Removing orphaned automations',
+                cancellable: false,
+            }, async (progress) => {
+                for (const orphan of orphanedItems) {
+                    try {
+                        const url = `${details.deployUrl}/automations/${orphan.deploymentId}`;
+                        await deleteAutomation(url, details.deploySecret);
+                        removed++;
+                        progress.report({ message: `${removed}/${orphanedItems.length}` });
+                    } catch {
+                        failed++;
+                    }
+                }
+            });
+
+            if (failed > 0) {
+                vscode.window.showWarningMessage(`Removed ${removed} automations, ${failed} failed.`);
+            } else {
+                vscode.window.showInformationMessage(`Removed ${removed} orphaned automations.`);
+            }
+            await automationCommands.refreshAutomationsCommand(context, automationsProvider);
+        });
+
     let createAutomationFileCommand = vscode.commands.registerCommand(
         'bitswan.createAutomationFile',
         async (item: AutomationSourceItem | AutomationSourceFileItem | StageItem) =>
@@ -1003,6 +1054,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(activateAutomationCommand);
     context.subscriptions.push(deactivateAutomationCommand);
     context.subscriptions.push(deleteAutomationCommand);
+    context.subscriptions.push(removeAllOrphanedCommand);
     context.subscriptions.push(createAutomationFileCommand);
     context.subscriptions.push(createAutomationFolderCommand);
     context.subscriptions.push(renameAutomationResourceCommand);

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -756,12 +756,19 @@ export function activate(context: vscode.ExtensionContext) {
                 cancellable: false,
             }, async (progress) => {
                 for (const orphan of orphaned) {
+                    const depId = orphan.deploymentId;
                     try {
-                        const url = `${details.deployUrl}/automations/${orphan.deploymentId}`;
-                        await deleteAutomation(url, details.deploySecret);
-                        removed++;
-                        progress.report({ message: `${removed}/${orphaned.length}` });
-                    } catch {
+                        const url = `${details.deployUrl}/automations/${depId}`;
+                        const success = await deleteAutomation(url, details.deploySecret);
+                        if (success) {
+                            removed++;
+                        } else {
+                            outputChannel.appendLine(`Failed to remove orphaned automation: ${depId}`);
+                            failed++;
+                        }
+                        progress.report({ message: `${removed + failed}/${orphaned.length}` });
+                    } catch (err: any) {
+                        outputChannel.appendLine(`Error removing ${depId}: ${err.message}`);
                         failed++;
                     }
                 }
@@ -772,7 +779,9 @@ export function activate(context: vscode.ExtensionContext) {
             } else {
                 vscode.window.showInformationMessage(`Removed ${removed} orphaned automations.`);
             }
+            // Refresh both the automations state and the unified view
             await automationCommands.refreshAutomationsCommand(context, automationsProvider);
+            unifiedBusinessProcessesProvider.refresh();
         });
 
     let createAutomationFileCommand = vscode.commands.registerCommand(

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import urlJoin from 'proper-url-join';
 
 import { AutomationItem } from './views/automations_view';
 import { ImageItem } from './views/unified_images_view';
@@ -727,8 +728,11 @@ export function activate(context: vscode.ExtensionContext) {
 
     let removeAllOrphanedCommand = vscode.commands.registerCommand('bitswan.removeAllOrphaned',
         async (item: OtherAutomationsItem) => {
-            const details = await getDeployDetails(context);
-            if (!details) { return; }
+            const activeInstance = context.globalState.get<any>('activeGitOpsInstance');
+            if (!activeInstance) {
+                vscode.window.showErrorMessage('No active GitOps instance');
+                return;
+            }
 
             // Get orphaned items from the unified view provider
             const children = await unifiedBusinessProcessesProvider.getChildren(item);
@@ -756,30 +760,30 @@ export function activate(context: vscode.ExtensionContext) {
                 cancellable: false,
             }, async (progress) => {
                 for (const orphan of orphaned) {
-                    const depId = orphan.deploymentId;
                     try {
-                        const url = `${details.deployUrl}/automations/${depId}`;
-                        const success = await deleteAutomation(url, details.deploySecret);
+                        // Use the same URL pattern as the working single-delete:
+                        // urlJoin(activeInstance.url, "automations", item.name)
+                        const url = urlJoin(activeInstance.url, "automations", orphan.name).toString();
+                        const success = await deleteAutomation(url, activeInstance.secret);
                         if (success) {
                             removed++;
                         } else {
-                            outputChannel.appendLine(`Failed to remove orphaned automation: ${depId}`);
+                            outputChannel.appendLine(`Failed to remove: ${orphan.name}`);
                             failed++;
                         }
                         progress.report({ message: `${removed + failed}/${orphaned.length}` });
                     } catch (err: any) {
-                        outputChannel.appendLine(`Error removing ${depId}: ${err.message}`);
+                        outputChannel.appendLine(`Error removing ${orphan.name}: ${err.message}`);
                         failed++;
                     }
                 }
             });
 
             if (failed > 0) {
-                vscode.window.showWarningMessage(`Removed ${removed} automations, ${failed} failed.`);
+                vscode.window.showWarningMessage(`Removed ${removed}, ${failed} failed.`);
             } else {
                 vscode.window.showInformationMessage(`Removed ${removed} orphaned automations.`);
             }
-            // Refresh both the automations state and the unified view
             await automationCommands.refreshAutomationsCommand(context, automationsProvider);
             unifiedBusinessProcessesProvider.refresh();
         });


### PR DESCRIPTION
## Summary
Adds a trash icon button on the "Other" folder in the unified business processes view. Clicking it removes all orphaned automations (those not claimed by any stage/source).

- Confirmation dialog shows the count before deleting
- Progress notification during removal
- Refreshes the automations list after completion

## Test plan
- [ ] Right-click or click trash icon on "Other" folder
- [ ] Confirm removal dialog appears with correct count
- [ ] Verify all orphaned automations are removed
- [ ] Verify the Other section is empty after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)