### PR TITLE
Unified Dashboard: automations, requirements, README, terminals

### DIFF
--- a/Extension/package-lock.json
+++ b/Extension/package-lock.json
@@ -17,6 +17,8 @@
         "configparser": "^0.3.10",
         "form-data": "^4.0.0",
         "jszip": "^3.10.1",
+        "marked": "^16.4.2",
+        "mermaid": "^11.14.0",
         "minimatch": "^9.0.5",
         "nanoid": "^5.1.5",
         "proper-url-join": "^2.1.2",
@@ -34,6 +36,19 @@
       },
       "engines": {
         "vscode": "^1.92.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -159,6 +174,49 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -246,6 +304,23 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -313,6 +388,15 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -371,6 +455,265 @@
         "@types/readdir-glob": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -410,6 +753,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/vscode": {
       "version": "1.99.1",
@@ -580,6 +930,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
       }
     },
     "node_modules/@vscode/jupyter-extension": {
@@ -1200,6 +1560,34 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -1336,6 +1724,12 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/configparser": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/configparser/-/configparser-0.3.10.tgz",
@@ -1350,6 +1744,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -1493,6 +1896,520 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -1550,6 +2467,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1634,6 +2560,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -2434,6 +3369,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2612,6 +3553,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2747,6 +3697,31 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keytar": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
@@ -2767,6 +3742,35 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/langium": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -2827,6 +3831,12 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2884,6 +3894,18 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2907,6 +3929,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/micromatch": {
@@ -3027,6 +4078,30 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3156,6 +4231,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -3242,6 +4323,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3292,6 +4379,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3316,6 +4409,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -3610,6 +4730,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3633,6 +4771,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -3992,6 +5136,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4104,6 +5254,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -4124,6 +5283,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -4227,6 +5395,12 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "license": "MIT"
     },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
+    },
     "node_modules/underscore": {
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
@@ -4263,6 +5437,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache": {
       "version": "2.4.0",
@@ -4397,6 +5584,55 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -962,6 +962,8 @@
     "configparser": "^0.3.10",
     "form-data": "^4.0.0",
     "jszip": "^3.10.1",
+    "marked": "^16.4.2",
+    "mermaid": "^11.14.0",
     "minimatch": "^9.0.5",
     "nanoid": "^5.1.5",
     "proper-url-join": "^2.1.2",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -472,27 +472,27 @@
         },
         {
           "command": "bitswan.startLiveDevServer",
-          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "when": "view == bitswan-unified-business-processes && viewItem =~ /^worktreeAutomation,notDeployed/",
           "group": "inline@1"
         },
         {
           "command": "bitswan.showAutomationLogs",
-          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "when": "view == bitswan-unified-business-processes && viewItem =~ /^worktreeAutomation,(running|exited|dead)/",
           "group": "inline@2"
         },
         {
           "command": "bitswan.restartAutomation",
-          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "when": "view == bitswan-unified-business-processes && viewItem =~ /^worktreeAutomation,(running|exited|dead)/",
           "group": "inline@3"
         },
         {
           "command": "bitswan.openExternalUrl",
-          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "when": "view == bitswan-unified-business-processes && viewItem =~ /^worktreeAutomation,.*,url/",
           "group": "inline@4"
         },
         {
           "command": "bitswan.deleteAutomation",
-          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "when": "view == bitswan-unified-business-processes && viewItem =~ /^worktreeAutomation,(running|exited|dead)/",
           "group": "inline@5"
         },
         {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -436,7 +436,7 @@
       },
       {
         "command": "bitswan.openRequirementsEditor",
-        "title": "Open Requirements Editor",
+        "title": "Open Workspace",
         "category": "BitSwan"
       },
       {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -471,6 +471,31 @@
           "group": "inline"
         },
         {
+          "command": "bitswan.startLiveDevServer",
+          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "group": "inline@1"
+        },
+        {
+          "command": "bitswan.showAutomationLogs",
+          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "group": "inline@2"
+        },
+        {
+          "command": "bitswan.restartAutomation",
+          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "group": "inline@3"
+        },
+        {
+          "command": "bitswan.openExternalUrl",
+          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "group": "inline@4"
+        },
+        {
+          "command": "bitswan.deleteAutomation",
+          "when": "view == bitswan-unified-business-processes && viewItem == worktreeAutomation",
+          "group": "inline@5"
+        },
+        {
           "command": "bitswan.jumpToSource",
           "when": "view == bitswan-unified-business-processes && viewItem == automationSource",
           "group": "inline@6"

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -471,11 +471,6 @@
           "group": "inline"
         },
         {
-          "command": "bitswan.startLiveDevServer",
-          "when": "view == bitswan-unified-business-processes && viewItem == automationSource",
-          "group": "inline@2"
-        },
-        {
           "command": "bitswan.jumpToSource",
           "when": "view == bitswan-unified-business-processes && viewItem == automationSource",
           "group": "inline@6"
@@ -562,7 +557,7 @@
         },
         {
           "command": "bitswan.startLiveDevServer",
-          "when": "view == bitswan-unified-business-processes && viewItem =~ /^automationStage,live-dev,notDeployed/",
+          "when": "false",
           "group": "inline@1"
         },
         {

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -1163,6 +1163,9 @@ export function activate(context: vscode.ExtensionContext) {
         }
     };
     context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
+
+    // Auto-open the Dashboard on startup
+    DashboardPanel.createOrShow(context);
 }
 
 /**

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -34,7 +34,7 @@ import { Jupyter } from '@vscode/jupyter-extension';
 import { getJupyterServers } from './commands/jupyter-server';
 import { startBitswanKernel, stopBitswanKernel, checkAndUpdateKernelStatus, updateKernelStatusContext } from './commands/kernel';
 import * as filesystemCommands from './commands/filesystem';
-import { initUserInfo } from './services/user_info';
+import { initUserInfo, getUserEmail } from './services/user_info';
 import { WorktreesViewProvider } from './views/worktrees_view';
 import { createWorktreeCommand as createWorktreeCmd, deleteWorktreeCommand as deleteWorktreeCmd, openAgentTerminalCommand as openAgentTerminalCmd, viewWorktreeDiffCommand as viewWorktreeDiffCmd } from './commands/worktrees';
 import { AgentSessionPanel, startAgentSession } from './commands/agent_sessions';
@@ -1164,8 +1164,10 @@ export function activate(context: vscode.ExtensionContext) {
     };
     context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
 
-    // Auto-open the Dashboard on startup
-    DashboardPanel.createOrShow(context);
+    // Auto-open the Dashboard on startup, after user info has been fetched
+    getUserEmail(context).finally(() => {
+        DashboardPanel.createOrShow(context);
+    });
 }
 
 /**

--- a/Extension/src/extension.ts
+++ b/Extension/src/extension.ts
@@ -38,7 +38,7 @@ import { initUserInfo } from './services/user_info';
 import { WorktreesViewProvider } from './views/worktrees_view';
 import { createWorktreeCommand as createWorktreeCmd, deleteWorktreeCommand as deleteWorktreeCmd, openAgentTerminalCommand as openAgentTerminalCmd, viewWorktreeDiffCommand as viewWorktreeDiffCmd } from './commands/worktrees';
 import { AgentSessionPanel, startAgentSession } from './commands/agent_sessions';
-import { RequirementsPanel } from './views/requirements_view';
+import { DashboardPanel } from './views/dashboard_panel';
 import { BackupsPanel } from './views/backups_view';
 
 // Defining logging channel
@@ -186,7 +186,7 @@ export function activate(context: vscode.ExtensionContext) {
         }),
         vscode.commands.registerCommand('bitswan.viewWorktreeDiff', (item) => viewWorktreeDiffCmd(context, item)),
         vscode.commands.registerCommand('bitswan.openSessionBrowser', () => AgentSessionPanel.createOrShow(context)),
-        vscode.commands.registerCommand('bitswan.openRequirementsEditor', () => RequirementsPanel.createOrShow(context)),
+        vscode.commands.registerCommand('bitswan.openRequirementsEditor', () => DashboardPanel.createOrShow(context)),
         vscode.commands.registerCommand('bitswan.openBackups', () => BackupsPanel.createOrShow(context)),
         vscode.commands.registerCommand('bitswan.refreshWorktrees', () => worktreesProvider.refresh()),
         vscode.commands.registerCommand('bitswan.selectWorktree', (name?: string) => {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -359,93 +359,100 @@ export class DashboardPanel {
     // ---- Terminals ----
 
     private async openCodingAgentTerminal(worktree: string, bpPath: string): Promise<void> {
-        if (!worktree) {
-            vscode.window.showErrorMessage('Coding agent is only available for worktrees.');
-            return;
+        if (worktree) {
+            // Worktree: SSH into coding agent container
+            const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
+            const agentHost = `${workspaceName}-coding-agent`;
+
+            const reachable = await new Promise<boolean>(resolve => {
+                cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
+            });
+
+            if (!reachable) {
+                vscode.window.showErrorMessage('Coding agent container is not running. Start it from the worktrees view.');
+                return;
+            }
+
+            const userEmail = await getUserEmail(this.context);
+            const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
+
+            const terminal = vscode.window.createTerminal({
+                name: `Claude: ${worktree}/${bpPath}`,
+                shellPath: '/usr/bin/ssh',
+                shellArgs: [
+                    '-i', '/workspace/.ssh/id_ed25519',
+                    '-o', 'StrictHostKeyChecking=no',
+                    '-o', 'UserKnownHostsFile=/dev/null',
+                    '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
+                    `agent@${agentHost}`,
+                ],
+                env: {
+                    SSH_USER_EMAIL: userEmail,
+                    SSH_LOGGED: 'true',
+                    SSH_WORKTREE: worktree,
+                },
+            });
+            terminal.show(true);
+            setTimeout(() => {
+                terminal.sendText(`cd "${cdPath}" && claude --dangerously-skip-permissions`);
+            }, 2000);
+        } else {
+            // Main workspace: local terminal
+            const cdPath = path.join(WORKSPACE_DIR, bpPath);
+            const terminal = vscode.window.createTerminal({
+                name: `Claude: ${bpPath}`,
+                cwd: cdPath,
+            });
+            terminal.show(true);
+            terminal.sendText('claude --dangerously-skip-permissions');
         }
-
-        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
-        const agentHost = `${workspaceName}-coding-agent`;
-
-        // Check if agent container is reachable
-        const reachable = await new Promise<boolean>(resolve => {
-            cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
-        });
-
-        if (!reachable) {
-            vscode.window.showErrorMessage('Coding agent container is not running. Start it from the worktrees view.');
-            return;
-        }
-
-        const userEmail = await getUserEmail(this.context);
-        const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
-
-        const terminal = vscode.window.createTerminal({
-            name: `Claude: ${worktree}/${bpPath}`,
-            shellPath: '/usr/bin/ssh',
-            shellArgs: [
-                '-i', '/workspace/.ssh/id_ed25519',
-                '-o', 'StrictHostKeyChecking=no',
-                '-o', 'UserKnownHostsFile=/dev/null',
-                '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
-                `agent@${agentHost}`,
-            ],
-            env: {
-                SSH_USER_EMAIL: userEmail,
-                SSH_LOGGED: 'true',
-                SSH_WORKTREE: worktree,
-            },
-        });
-        terminal.show(true);
-
-        // After SSH connects, cd and launch claude
-        setTimeout(() => {
-            terminal.sendText(`cd "${cdPath}" && claude --dangerously-skip-permissions`);
-        }, 2000);
     }
 
     private async openPlainTerminal(worktree: string, bpPath: string): Promise<void> {
-        if (!worktree) {
-            vscode.window.showErrorMessage('Terminal is only available for worktrees.');
-            return;
+        if (worktree) {
+            const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
+            const agentHost = `${workspaceName}-coding-agent`;
+
+            const reachable = await new Promise<boolean>(resolve => {
+                cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
+            });
+
+            if (!reachable) {
+                vscode.window.showErrorMessage('Coding agent container is not running.');
+                return;
+            }
+
+            const userEmail = await getUserEmail(this.context);
+            const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
+
+            const terminal = vscode.window.createTerminal({
+                name: `Terminal: ${worktree}/${bpPath}`,
+                shellPath: '/usr/bin/ssh',
+                shellArgs: [
+                    '-i', '/workspace/.ssh/id_ed25519',
+                    '-o', 'StrictHostKeyChecking=no',
+                    '-o', 'UserKnownHostsFile=/dev/null',
+                    '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
+                    `agent@${agentHost}`,
+                ],
+                env: {
+                    SSH_USER_EMAIL: userEmail,
+                    SSH_LOGGED: 'false',
+                    SSH_WORKTREE: worktree,
+                },
+            });
+            terminal.show(true);
+            setTimeout(() => {
+                terminal.sendText(`cd "${cdPath}"`);
+            }, 2000);
+        } else {
+            const cdPath = path.join(WORKSPACE_DIR, bpPath);
+            const terminal = vscode.window.createTerminal({
+                name: `Terminal: ${bpPath}`,
+                cwd: cdPath,
+            });
+            terminal.show(true);
         }
-
-        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
-        const agentHost = `${workspaceName}-coding-agent`;
-
-        const reachable = await new Promise<boolean>(resolve => {
-            cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
-        });
-
-        if (!reachable) {
-            vscode.window.showErrorMessage('Coding agent container is not running.');
-            return;
-        }
-
-        const userEmail = await getUserEmail(this.context);
-        const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
-
-        const terminal = vscode.window.createTerminal({
-            name: `Terminal: ${worktree}/${bpPath}`,
-            shellPath: '/usr/bin/ssh',
-            shellArgs: [
-                '-i', '/workspace/.ssh/id_ed25519',
-                '-o', 'StrictHostKeyChecking=no',
-                '-o', 'UserKnownHostsFile=/dev/null',
-                '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
-                `agent@${agentHost}`,
-            ],
-            env: {
-                SSH_USER_EMAIL: userEmail,
-                SSH_LOGGED: 'false',
-                SSH_WORKTREE: worktree,
-            },
-        });
-        terminal.show(true);
-
-        setTimeout(() => {
-            terminal.sendText(`cd "${cdPath}"`);
-        }, 2000);
     }
 
     private postMessage(msg: any): void {
@@ -622,7 +629,7 @@ export class DashboardPanel {
             }
 
             // Action cards (Coding Agent + Terminal) — only for worktrees
-            if (bpData.worktree) {
+            {
                 var actionsSection = mkEl('div', 'section');
                 actionsSection.appendChild(mkEl('div', 'section-title', 'Actions'));
                 var actionsRow = mkEl('div', 'action-cards');

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -461,19 +461,18 @@ export class DashboardPanel {
 
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const logged = anon ? 'false' : 'true';
-            const sshCmd = `SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' ssh -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE' agent@${agentHost}`;
+            const autoCmd = `cd '${cdPath}' && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
             const terminal = vscode.window.createTerminal({
                 name: `Claude: ${worktree}/${bpPath}`,
+                shellPath: '/bin/bash',
+                shellArgs: ['-c', `exec SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' SSH_AUTO_CMD='${autoCmd.replace(/'/g, "'\\''")}' ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`],
             });
             terminal.show(true);
-            terminal.sendText(sshCmd);
 
-            // Track active session
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
             this.sendActiveSessions();
 
-            // Remove when terminal closes and refresh sessions
             const disposable = vscode.window.onDidCloseTerminal(t => {
                 if (t.name === termName) {
                     const idx = activeSessions.findIndex(s => s.terminalName === termName);
@@ -485,10 +484,6 @@ export class DashboardPanel {
                     disposable.dispose();
                 }
             });
-
-            setTimeout(() => {
-                terminal.sendText(`cd "${cdPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions`);
-            }, 3000);
 
             // Refresh sessions after meta.json is created by the agent container
             setTimeout(() => this._reloadCurrentKey(), 5000);
@@ -523,12 +518,13 @@ export class DashboardPanel {
 
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const logged = anon ? 'false' : 'true';
-            const sshCmd = `SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' ssh -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE' agent@${agentHost}`;
+            const autoCmd = `cd '${cdPath}' && exec bash`;
             const terminal = vscode.window.createTerminal({
                 name: `Terminal: ${worktree}/${bpPath}`,
+                shellPath: '/bin/bash',
+                shellArgs: ['-c', `exec SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' SSH_AUTO_CMD='${autoCmd.replace(/'/g, "'\\''")}' ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`],
             });
             terminal.show(true);
-            terminal.sendText(sshCmd);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
@@ -740,16 +736,13 @@ export class DashboardPanel {
             `4. Once the merge is complete, tell the user it's done`,
         ].join('\\n');
 
-        const sshCmd = `SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='true' SSH_WORKTREE='${worktree}' ssh -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE' agent@${agentHost}`;
+        const mergeAutoCmd = `cd '${wtPath}' && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
         const terminal = vscode.window.createTerminal({
             name: `Merge: ${worktree}`,
+            shellPath: '/bin/bash',
+            shellArgs: ['-c', `exec SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='true' SSH_WORKTREE='${worktree}' SSH_AUTO_CMD='${mergeAutoCmd.replace(/'/g, "'\\''")}' ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`],
         });
         terminal.show(true);
-        terminal.sendText(sshCmd);
-
-        setTimeout(() => {
-            terminal.sendText(`cd "${wtPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions -p "${claudePrompt}"`);
-        }, 3000);
     }
 
     private sendActiveSessions(): void {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -869,7 +869,7 @@ export class DashboardPanel {
                 var tab = document.createElement('div');
                 tab.className = 'tab' + (idx === currentWsIdx ? ' active' : '');
                 tab.textContent = ws.name;
-                tab.addEventListener('click', function() { currentWsIdx = idx; currentBpKey = ''; bpData = null; renderSubtabs(); renderContent(); });
+                tab.addEventListener('click', function() { currentWsIdx = idx; currentBpKey = ''; bpData = null; renderTabs(); renderSubtabs(); renderContent(); });
                 tabBar.appendChild(tab);
             });
             // "+ New Worktree" tab

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -35,7 +35,7 @@ function inferAutomationIcon(autoDir: string): string {
     try {
         const data = toml.parse(fs.readFileSync(configPath, 'utf-8')) as any;
         const dep = data.deployment || {};
-        const hasExposeTo = !!dep.expose_to;
+        const hasExposeTo = !!dep.expose_to || !!data.expose_to;
         const hasExpose = dep.expose === true;
         const hasKafka = !!(data.services?.kafka?.enabled);
         const image = (dep.image || '').toLowerCase();
@@ -90,6 +90,7 @@ export class DashboardPanel {
 
     private playerJsUri: vscode.Uri | undefined;
     private playerCssUri: vscode.Uri | undefined;
+    private codiconFontUri: vscode.Uri | undefined;
 
     private constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -98,6 +99,9 @@ export class DashboardPanel {
             path.join(context.extensionPath, 'node_modules', 'asciinema-player', 'dist', 'bundle')
         );
 
+        // Codicon font from code-server
+        const codiconDir = vscode.Uri.file('/usr/lib/code-server/lib/vscode/out/media');
+
         this.panel = vscode.window.createWebviewPanel(
             'bitswan-workspace',
             'Workspace',
@@ -105,7 +109,7 @@ export class DashboardPanel {
             {
                 enableScripts: true,
                 retainContextWhenHidden: true,
-                localResourceRoots: [asciinemaDir],
+                localResourceRoots: [asciinemaDir, codiconDir],
             },
         );
 
@@ -115,6 +119,9 @@ export class DashboardPanel {
         this.playerCssUri = this.panel.webview.asWebviewUri(vscode.Uri.file(
             path.join(context.extensionPath, 'node_modules', 'asciinema-player', 'dist', 'bundle', 'asciinema-player.css')
         ));
+        this.codiconFontUri = this.panel.webview.asWebviewUri(
+            vscode.Uri.file('/usr/lib/code-server/lib/vscode/out/media/codicon.ttf')
+        );
 
         this.panel.webview.html = this._getHtmlForWebview();
 
@@ -804,6 +811,12 @@ export class DashboardPanel {
 <head>
     <meta charset="UTF-8">
     <style>
+        @font-face { font-family: codicon; src: url(${this.codiconFontUri}); }
+        .codicon { font-family: codicon; font-size: 14px; line-height: 1; display: inline-block; }
+        .codicon-output::before { content: "\\eb9d"; }
+        .codicon-debug-restart::before { content: "\\eb4e"; }
+        .codicon-debug-start::before { content: "\\eb49"; }
+        .codicon-link-external::before { content: "\\eb05"; }
         :root { color-scheme: light dark; font-family: var(--vscode-font-family, sans-serif);
             --status-pass: #3fb950; --status-fail: #f85149; --status-pending: #d29922; --status-retest: #a371f7; --status-proposed: #768390; --border: var(--vscode-editorWidget-border, rgba(128,128,128,0.3)); }
         * { box-sizing: border-box; }
@@ -1081,7 +1094,9 @@ export class DashboardPanel {
                             top.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'openUrl', url: auto.url });
                             });
-                            top.appendChild(mkEl('span', 'auto-card-link-icon', '\\u{1F517}'));
+                            var linkIcon = mkEl('span', 'auto-card-link-icon');
+                            linkIcon.innerHTML = '<span class="codicon codicon-link-external"></span>';
+                            top.appendChild(linkIcon);
                         }
                         top.appendChild(mkEl('div', 'auto-card-icon', auto.icon || '\\u{1F4E6}'));
                         top.appendChild(mkEl('div', 'auto-card-name', auto.name));
@@ -1092,19 +1107,22 @@ export class DashboardPanel {
                         // Action buttons at bottom
                         var actions = mkEl('div', 'auto-card-actions');
                         if (auto.deploymentId) {
-                            var logsBtn = mkEl('button', 'btn', '\u{2261} Logs');
+                            var logsBtn = mkEl('button', 'btn', '');
+                            logsBtn.innerHTML = '<span class="codicon codicon-output"></span> Logs';
                             logsBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(logsBtn);
 
-                            var restartBtn = mkEl('button', 'btn', '\u{21BB} Restart');
+                            var restartBtn = mkEl('button', 'btn', '');
+                            restartBtn.innerHTML = '<span class="codicon codicon-debug-restart"></span> Restart';
                             restartBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(restartBtn);
                         } else if (bpData.worktree) {
-                            var startBtn = mkEl('button', 'btn btn-primary', '\u{25B6} Start Live Dev');
+                            var startBtn = mkEl('button', 'btn btn-primary', '');
+                            startBtn.innerHTML = '<span class="codicon codicon-debug-start"></span> Start Live Dev';
                             startBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'startLiveDev', relativePath: auto.relativePath, worktree: bpData.worktree, name: auto.name });
                             });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -91,6 +91,8 @@ export class DashboardPanel {
     private playerJsUri: vscode.Uri | undefined;
     private playerCssUri: vscode.Uri | undefined;
     private codiconFontUri: vscode.Uri | undefined;
+    private markedJsUri: vscode.Uri | undefined;
+    private mermaidJsUri: vscode.Uri | undefined;
 
     private constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -99,8 +101,9 @@ export class DashboardPanel {
             path.join(context.extensionPath, 'node_modules', 'asciinema-player', 'dist', 'bundle')
         );
 
-        // Codicon font from code-server
         const codiconDir = vscode.Uri.file('/usr/lib/code-server/lib/vscode/out/media');
+        const markedDir = vscode.Uri.file(path.join(context.extensionPath, 'node_modules', 'marked', 'lib'));
+        const mermaidDir = vscode.Uri.file(path.join(context.extensionPath, 'node_modules', 'mermaid', 'dist'));
 
         this.panel = vscode.window.createWebviewPanel(
             'bitswan-workspace',
@@ -109,7 +112,7 @@ export class DashboardPanel {
             {
                 enableScripts: true,
                 retainContextWhenHidden: true,
-                localResourceRoots: [asciinemaDir, codiconDir],
+                localResourceRoots: [asciinemaDir, codiconDir, markedDir, mermaidDir],
             },
         );
 
@@ -122,6 +125,12 @@ export class DashboardPanel {
         this.codiconFontUri = this.panel.webview.asWebviewUri(
             vscode.Uri.file('/usr/lib/code-server/lib/vscode/out/media/codicon.ttf')
         );
+        this.markedJsUri = this.panel.webview.asWebviewUri(vscode.Uri.file(
+            path.join(context.extensionPath, 'node_modules', 'marked', 'lib', 'marked.umd.js')
+        ));
+        this.mermaidJsUri = this.panel.webview.asWebviewUri(vscode.Uri.file(
+            path.join(context.extensionPath, 'node_modules', 'mermaid', 'dist', 'mermaid.min.js')
+        ));
 
         this.panel.webview.html = this._getHtmlForWebview();
 
@@ -139,6 +148,11 @@ export class DashboardPanel {
         const autoWatcher = vscode.workspace.createFileSystemWatcher('**/automation.toml');
         autoWatcher.onDidCreate(() => this._reloadCurrentKey());
         context.subscriptions.push(autoWatcher);
+
+        // Watch for README changes
+        const readmeWatcher = vscode.workspace.createFileSystemWatcher('**/README.md');
+        readmeWatcher.onDidChange(() => this._reloadCurrentKey());
+        context.subscriptions.push(readmeWatcher);
 
         this.panel.onDidDispose(() => {
             this.disposed = true;
@@ -262,6 +276,17 @@ export class DashboardPanel {
             case 'mergeWorktree':
                 await this.mergeWorktree(msg.worktree);
                 break;
+            case 'editReadme': {
+                const bpDir = this.bpMap.get(msg.key);
+                if (bpDir) {
+                    const readmePath = path.join(bpDir, 'README.md');
+                    if (fs.existsSync(readmePath)) {
+                        const doc = await vscode.workspace.openTextDocument(readmePath);
+                        await vscode.window.showTextDocument(doc);
+                    }
+                }
+                break;
+            }
             case 'revealInExplorer': {
                 const bpDir = this.bpMap.get(msg.key);
                 if (bpDir) {
@@ -833,6 +858,7 @@ export class DashboardPanel {
         .codicon-debug-start::before { content: "\\ead3"; }
         .codicon-link-external::before { content: "\\eb14"; }
         .codicon-folder-opened::before { content: "\\eaf7"; }
+        .codicon-edit::before { content: "\\ea73"; }
         :root { color-scheme: light dark; font-family: var(--vscode-font-family, sans-serif);
             --status-pass: #3fb950; --status-fail: #f85149; --status-pending: #d29922; --status-retest: #a371f7; --status-proposed: #768390; --border: var(--vscode-editorWidget-border, rgba(128,128,128,0.3)); }
         * { box-sizing: border-box; }
@@ -889,7 +915,17 @@ export class DashboardPanel {
         .btn-ghost:hover { background:var(--status-fail); color:#fff; }
 
         /* README */
-        .readme { padding:12px; border:1px solid var(--border); border-radius:8px; background:var(--vscode-sideBar-background, rgba(128,128,128,0.05)); font-size:12px; line-height:1.5; white-space:pre-wrap; max-height:200px; overflow-y:auto; }
+        .readme { padding:12px 16px; border:1px solid var(--border); border-radius:8px; background:var(--vscode-sideBar-background, rgba(128,128,128,0.05)); font-size:13px; line-height:1.6; max-height:400px; overflow-y:auto; }
+        .readme h1, .readme h2, .readme h3 { margin:12px 0 6px; }
+        .readme h1 { font-size:18px; } .readme h2 { font-size:16px; } .readme h3 { font-size:14px; }
+        .readme p { margin:6px 0; }
+        .readme code { background:rgba(128,128,128,0.15); padding:1px 4px; border-radius:3px; font-size:12px; }
+        .readme pre { background:rgba(0,0,0,0.2); padding:10px; border-radius:6px; overflow-x:auto; }
+        .readme pre code { background:none; padding:0; }
+        .readme ul, .readme ol { padding-left:20px; margin:6px 0; }
+        .readme a { color:var(--vscode-textLink-foreground, #3794ff); }
+        .readme img { max-width:100%; border-radius:4px; }
+        .readme .mermaid { margin:12px 0; }
 
         /* Requirements (from original) */
         .req-node { margin-bottom:6px; position:relative; }
@@ -1180,14 +1216,32 @@ export class DashboardPanel {
                 content.appendChild(autoSection);
             }
 
-            // README
+            // README — rendered markdown with mermaid diagrams
             if (bpData.readme) {
                 var readmeSection = mkEl('div', 'section');
-                readmeSection.appendChild(mkEl('div', 'section-title', 'README'));
+                var readmeHeader = mkEl('div', '');
+                readmeHeader.style.cssText = 'display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;';
+                readmeHeader.appendChild(mkEl('div', 'section-title', 'README'));
+                var editBtn = mkEl('button', 'btn btn-sm', '');
+                editBtn.innerHTML = '<span class="codicon codicon-edit"></span>';
+                editBtn.title = 'Edit README';
+                editBtn.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'editReadme', key: currentBpKey });
+                });
+                readmeHeader.appendChild(editBtn);
+                readmeSection.appendChild(readmeHeader);
+
                 var readmeDiv = mkEl('div', 'readme');
-                readmeDiv.textContent = bpData.readme;
+                readmeDiv.innerHTML = renderMarkdown(bpData.readme);
                 readmeSection.appendChild(readmeDiv);
                 content.appendChild(readmeSection);
+
+                // Render mermaid diagrams after DOM is ready
+                if (typeof mermaid !== 'undefined') {
+                    setTimeout(function() {
+                        try { mermaid.run({ nodes: readmeDiv.querySelectorAll('.mermaid') }); } catch(e) {}
+                    }, 100);
+                }
             }
 
             // Requirements
@@ -1473,6 +1527,31 @@ export class DashboardPanel {
         vscodeApi.postMessage({ type: 'ready' });
     </script>
     <script src="${this.playerJsUri}"></script>
+    <script src="${this.markedJsUri}"></script>
+    <script src="${this.mermaidJsUri}"></script>
+    <script>
+        // Initialize mermaid
+        if (typeof mermaid !== 'undefined') {
+            mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+        }
+
+        // Render markdown with mermaid code block support
+        function renderMarkdown(text) {
+            if (typeof marked === 'undefined') { return text; }
+            var renderer = new marked.Renderer();
+            var origCode = renderer.code;
+            renderer.code = function(code, language) {
+                // Handle both marked v4 ({text, lang}) and v12+ (code, language) signatures
+                var codeText = typeof code === 'object' ? code.text : code;
+                var codeLang = typeof code === 'object' ? code.lang : language;
+                if (codeLang === 'mermaid') {
+                    return '<div class="mermaid">' + codeText + '</div>';
+                }
+                return '<pre><code>' + (codeText || '').replace(/</g, '&lt;') + '</code></pre>';
+            };
+            return marked.parse(text, { renderer: renderer });
+        }
+    </script>
 </body>
 </html>
         `;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -25,6 +25,29 @@ interface AutomationInfo {
     state: string;
     url: string;
     relativePath: string;
+    icon: string;
+}
+
+function inferAutomationIcon(autoDir: string): string {
+    const configPath = path.join(autoDir, 'automation.toml');
+    if (!fs.existsSync(configPath)) { return '\u{1F4E6}'; } // 📦
+    try {
+        const data = toml.parse(fs.readFileSync(configPath, 'utf-8')) as any;
+        const dep = data.deployment || {};
+        const hasExposeTo = !!dep.expose_to;
+        const hasExpose = dep.expose === true;
+        const hasKafka = !!(data.services?.kafka?.enabled);
+        const image = (dep.image || '').toLowerCase();
+        const hasFrontendImage = image.includes('frontend');
+
+        if (hasExposeTo) { return '\u{1F512}'; }                    // 🔒 internal frontend
+        if (hasExpose && hasFrontendImage) { return '\u{1F310}'; }   // 🌐 public frontend
+        if (hasExpose) { return '\u{2699}\u{FE0F}'; }               // ⚙️ backend
+        if (hasKafka) { return '\u{26A1}'; }                         // ⚡ kafka/streaming
+        return '\u{1F4E6}';                                          // 📦 default
+    } catch {
+        return '\u{1F4E6}';
+    }
 }
 
 function parseRequirementsToml(content: string): Requirement[] {
@@ -148,6 +171,27 @@ export class DashboardPanel {
                     vscode.env.openExternal(vscode.Uri.parse(msg.url));
                 }
                 break;
+            case 'startLiveDev': {
+                if (msg.relativePath && msg.worktree) {
+                    try {
+                        const { startLiveDev } = require('../lib');
+                        const details = await getDeployDetails(this.context);
+                        if (details) {
+                            const result = await startLiveDev(details.deployUrl, details.deploySecret, msg.relativePath, msg.worktree);
+                            if (result.success) {
+                                vscode.window.showInformationMessage(`Live dev started for ${msg.name || 'automation'}`);
+                                // Refresh after deploy completes
+                                setTimeout(() => this._reloadCurrentKey(), 5000);
+                            } else {
+                                vscode.window.showErrorMessage('Failed to start live dev');
+                            }
+                        }
+                    } catch (err: any) {
+                        vscode.window.showErrorMessage(`Failed to start live dev: ${err.message}`);
+                    }
+                }
+                break;
+            }
             case 'showLogs':
                 if (msg.deploymentId) {
                     // Find the automation and trigger log viewer
@@ -318,6 +362,7 @@ export class DashboardPanel {
                 state: match ? (match.state || 'not deployed') : 'not deployed',
                 url: match ? (match.automation_url || match.automationUrl || '') : '',
                 relativePath: relFromWorkspace,
+                icon: inferAutomationIcon(autoDir),
             });
         }
 
@@ -1029,6 +1074,9 @@ export class DashboardPanel {
                         }
 
                         var header = mkEl('div', 'auto-card-header');
+                        var iconSpan = mkEl('span', '', auto.icon || '\\u{1F4E6}');
+                        iconSpan.style.fontSize = '20px';
+                        header.appendChild(iconSpan);
                         header.appendChild(mkEl('span', 'auto-card-name', auto.name));
                         var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
                         header.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
@@ -1041,23 +1089,30 @@ export class DashboardPanel {
                             card.appendChild(urlLine);
                         }
 
+                        var actions = mkEl('div', 'auto-card-actions');
                         if (auto.deploymentId) {
-                            var actions = mkEl('div', 'auto-card-actions');
-                            var logsBtn = mkEl('button', 'btn', 'Logs');
+                            var logsBtn = mkEl('button', 'btn', '\\u{1F4CB} Logs');
                             logsBtn.addEventListener('click', function(e) {
                                 e.stopPropagation();
                                 vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(logsBtn);
 
-                            var restartBtn = mkEl('button', 'btn', 'Restart');
+                            var restartBtn = mkEl('button', 'btn', '\\u{1F504} Restart');
                             restartBtn.addEventListener('click', function(e) {
                                 e.stopPropagation();
                                 vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(restartBtn);
-                            card.appendChild(actions);
+                        } else if (bpData.worktree) {
+                            var startBtn = mkEl('button', 'btn btn-primary', '\\u{25B6} Start Live Dev');
+                            startBtn.addEventListener('click', function(e) {
+                                e.stopPropagation();
+                                vscodeApi.postMessage({ type: 'startLiveDev', relativePath: auto.relativePath, worktree: bpData.worktree, name: auto.name });
+                            });
+                            actions.appendChild(startBtn);
                         }
+                        card.appendChild(actions);
 
                         autoCards.appendChild(card);
                     });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -548,6 +548,7 @@ export class DashboardPanel {
         body { margin:0; padding:0; font-size:13px; color:var(--vscode-foreground); background:var(--vscode-editor-background); display:flex; flex-direction:column; height:100vh; overflow:hidden; }
         .header { display:flex; align-items:center; gap:12px; padding:12px 16px; border-bottom:1px solid var(--border); flex-shrink:0; }
         .header h2 { margin:0; font-size:16px; }
+        .tab-label { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:0.5px; color:var(--vscode-descriptionForeground); padding:6px 8px 6px 0; white-space:nowrap; }
         .tab-bar { display:flex; border-bottom:2px solid var(--border); flex-shrink:0; padding:0 8px; }
         .tab { padding:8px 16px; cursor:pointer; font-size:12px; font-weight:500; border-bottom:2px solid transparent; margin-bottom:-2px; color:var(--vscode-descriptionForeground); }
         .tab:hover { color:var(--vscode-foreground); }
@@ -621,8 +622,14 @@ export class DashboardPanel {
 </head>
 <body>
     <div class="header"><h2>Dashboard</h2></div>
-    <div class="tab-bar" id="tabBar"></div>
-    <div class="subtab-bar" id="subtabBar"></div>
+    <div style="display:flex; align-items:center; padding:0 8px;">
+        <span class="tab-label">Worktrees</span>
+        <div class="tab-bar" id="tabBar" style="flex:1;"></div>
+    </div>
+    <div style="display:flex; align-items:center; padding:0 8px;">
+        <span class="tab-label">Business Processes</span>
+        <div class="subtab-bar" id="subtabBar" style="flex:1;"></div>
+    </div>
     <div class="content" id="content">
         <div class="placeholder" id="placeholder">Loading...</div>
     </div>

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -38,11 +38,12 @@ function inferAutomationIcon(autoDir: string): string {
         const hasExpose = dep.expose === true;
         const hasKafka = !!(data.services?.kafka?.enabled);
         const image = (dep.image || '').toLowerCase();
-        const hasFrontendImage = image.includes('frontend');
+        const dirName = path.basename(autoDir).toLowerCase();
+        const isFrontend = image.includes('frontend') || dirName.includes('frontend');
 
-        if (hasExposeTo) { return '\u{1F512}'; }                    // 🔒 internal frontend
-        if (hasExpose && hasFrontendImage) { return '\u{1F310}'; }   // 🌐 public frontend
-        if (hasExpose) { return '\u{2699}\u{FE0F}'; }               // ⚙️ backend
+        if (hasExposeTo) { return '\u{1F512}'; }                    // 🔒 internal frontend (OAuth protected)
+        if (hasExpose && isFrontend) { return '\u{1F310}'; }        // 🌐 public frontend
+        if (hasExpose) { return '\u{2699}\u{FE0F}'; }               // ⚙️ backend (exposed API)
         if (hasKafka) { return '\u{26A1}'; }                         // ⚡ kafka/streaming
         return '\u{1F4E6}';                                          // 📦 default
     } catch {
@@ -831,16 +832,18 @@ export class DashboardPanel {
         .action-card .card-desc { font-size:11px; color:var(--vscode-descriptionForeground); margin-top:2px; }
 
         /* Automation cards */
-        .auto-cards { display:flex; gap:10px; flex-wrap:wrap; }
-        .auto-card { flex:1; min-width:200px; max-width:350px; padding:12px; border:1px solid var(--border); border-radius:8px; cursor:pointer; transition: border-color 0.15s; }
-        .auto-card:hover { border-color:var(--vscode-focusBorder, #007acc); }
-        .auto-card-header { display:flex; align-items:center; gap:8px; margin-bottom:6px; }
-        .auto-card-name { font-weight:600; font-size:13px; }
-        .auto-card-state { font-size:10px; padding:2px 6px; border-radius:8px; text-transform:uppercase; font-weight:600; }
+        .auto-cards { display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:12px; }
+        .auto-card { display:flex; flex-direction:column; padding:16px; border:1px solid var(--border); border-radius:10px; transition: border-color 0.15s, box-shadow 0.15s; }
+        .auto-card:hover { border-color:var(--vscode-focusBorder, #007acc); box-shadow:0 2px 8px rgba(0,0,0,0.1); }
+        .auto-card-icon { font-size:28px; margin-bottom:10px; }
+        .auto-card-name { font-weight:600; font-size:14px; margin-bottom:4px; }
+        .auto-card-state { display:inline-block; font-size:10px; padding:2px 8px; border-radius:10px; text-transform:uppercase; font-weight:600; letter-spacing:0.3px; margin-bottom:8px; }
         .auto-card-state.running { background:var(--status-pass); color:#fff; }
         .auto-card-state.exited, .auto-card-state.dead { background:var(--status-fail); color:#fff; }
         .auto-card-state.not-deployed { background:var(--status-proposed); color:#fff; }
-        .auto-card-actions { display:flex; gap:6px; margin-top:8px; }
+        .auto-card-url { font-size:11px; color:var(--vscode-descriptionForeground); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; margin-bottom:8px; }
+        .auto-card-spacer { flex:1; }
+        .auto-card-actions { display:flex; gap:6px; border-top:1px solid var(--border); padding-top:10px; margin-top:4px; }
 
         /* Buttons */
         .btn { padding:4px 10px; border:1px solid var(--vscode-button-border, transparent); border-radius:4px; background:var(--vscode-button-secondaryBackground, rgba(128,128,128,0.2)); color:var(--vscode-button-secondaryForeground, var(--vscode-foreground)); cursor:pointer; font-size:11px; }
@@ -1066,46 +1069,50 @@ export class DashboardPanel {
                 if (bpData.automations) {
                     bpData.automations.forEach(function(auto) {
                         var card = mkEl('div', 'auto-card');
+
+                        // Icon
+                        card.appendChild(mkEl('div', 'auto-card-icon', auto.icon || '\\u{1F4E6}'));
+
+                        // Name
+                        card.appendChild(mkEl('div', 'auto-card-name', auto.name));
+
+                        // State badge
+                        var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
+                        card.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
+
+                        // URL
                         if (auto.url) {
-                            card.addEventListener('click', function(e) {
-                                if (e.target.tagName === 'BUTTON') return;
+                            var urlEl = mkEl('div', 'auto-card-url');
+                            urlEl.textContent = auto.url;
+                            urlEl.style.cursor = 'pointer';
+                            urlEl.addEventListener('click', function(e) {
+                                e.stopPropagation();
                                 vscodeApi.postMessage({ type: 'openUrl', url: auto.url });
                             });
+                            card.appendChild(urlEl);
                         }
 
-                        var header = mkEl('div', 'auto-card-header');
-                        var iconSpan = mkEl('span', '', auto.icon || '\\u{1F4E6}');
-                        iconSpan.style.fontSize = '20px';
-                        header.appendChild(iconSpan);
-                        header.appendChild(mkEl('span', 'auto-card-name', auto.name));
-                        var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
-                        header.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
-                        card.appendChild(header);
+                        // Spacer pushes actions to bottom
+                        card.appendChild(mkEl('div', 'auto-card-spacer'));
 
-                        if (auto.url) {
-                            var urlLine = mkEl('div', '', '');
-                            urlLine.style.cssText = 'font-size:11px; color:var(--vscode-descriptionForeground); margin-bottom:4px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;';
-                            urlLine.textContent = auto.url;
-                            card.appendChild(urlLine);
-                        }
-
+                        // Action buttons
                         var actions = mkEl('div', 'auto-card-actions');
                         if (auto.deploymentId) {
-                            var logsBtn = mkEl('button', 'btn', '\\u{1F4CB} Logs');
+                            var logsBtn = mkEl('button', 'btn', 'Logs');
                             logsBtn.addEventListener('click', function(e) {
                                 e.stopPropagation();
                                 vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(logsBtn);
 
-                            var restartBtn = mkEl('button', 'btn', '\\u{1F504} Restart');
+                            var restartBtn = mkEl('button', 'btn', 'Restart');
                             restartBtn.addEventListener('click', function(e) {
                                 e.stopPropagation();
                                 vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(restartBtn);
                         } else if (bpData.worktree) {
-                            var startBtn = mkEl('button', 'btn btn-primary', '\\u{25B6} Start Live Dev');
+                            var startBtn = mkEl('button', 'btn btn-primary', 'Start Live Dev');
                             startBtn.addEventListener('click', function(e) {
                                 e.stopPropagation();
                                 vscodeApi.postMessage({ type: 'startLiveDev', relativePath: auto.relativePath, worktree: bpData.worktree, name: auto.name });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -256,6 +256,9 @@ export class DashboardPanel {
             case 'createAutomation':
                 await this.createAutomation(msg.worktree, msg.bpPath);
                 break;
+            case 'syncWorktree':
+                await this.syncWorktree(msg.worktree);
+                break;
             case 'mergeWorktree':
                 await this.mergeWorktree(msg.worktree);
                 break;
@@ -711,13 +714,57 @@ export class DashboardPanel {
         vscode.commands.executeCommand('bitswan.openAutomationTemplates', relPath);
     }
 
+    private async syncWorktree(worktree: string): Promise<void> {
+        const details = await getDeployDetails(this.context);
+        if (!details) { return; }
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: `Syncing worktree "${worktree}" with main...`,
+            cancellable: false,
+        }, async () => {
+            try {
+                // Commit any uncommitted changes first
+                try {
+                    await axios.post(
+                        `${details.deployUrl}/agent/worktrees/${worktree}/vcs/commit`,
+                        { message: 'Pre-sync commit' },
+                        { headers: { Authorization: `Bearer ${details.deploySecret}` } },
+                    );
+                } catch { /* nothing to commit */ }
+
+                const result = await axios.post(
+                    `${details.deployUrl}/agent/worktrees/${worktree}/sync`,
+                    {},
+                    {
+                        headers: { Authorization: `Bearer ${details.deploySecret}` },
+                        validateStatus: () => true,
+                    },
+                );
+
+                const data = result.data;
+                if (data.status === 'synced' || data.status === 'success' || data.status === 'already_up_to_date') {
+                    vscode.window.showInformationMessage(`Worktree "${worktree}" synced with main.`);
+                } else if (data.status === 'conflicts') {
+                    const conflictedFiles = (data.conflicted_files || []).join(', ');
+                    vscode.window.showWarningMessage(`Sync has conflicts in: ${conflictedFiles}. Launching Claude to resolve.`);
+                    await this.launchMergeConflictAgent(worktree, data.conflicted_files || []);
+                } else {
+                    vscode.window.showErrorMessage(`Sync failed: ${data.detail || data.message || JSON.stringify(data)}`);
+                }
+            } catch (err: any) {
+                vscode.window.showErrorMessage(`Sync failed: ${err.message}`);
+            }
+        });
+    }
+
     private async mergeWorktree(worktree: string): Promise<void> {
         const confirm = await vscode.window.showWarningMessage(
-            `Merge worktree "${worktree}" into the main branch?`,
+            `Merge worktree "${worktree}" into main and delete the worktree?`,
             { modal: true },
-            'Merge',
+            'Merge & Delete',
         );
-        if (confirm !== 'Merge') { return; }
+        if (confirm !== 'Merge & Delete') { return; }
 
         const details = await getDeployDetails(this.context);
         if (!details) { return; }
@@ -745,23 +792,16 @@ export class DashboardPanel {
             const data = result.data;
 
             if (data.status === 'merged' || data.status === 'success') {
-                // Merge succeeded — ask to delete worktree
+                // Merge succeeded — delete worktree automatically
                 const merged_into = data.merged_into || 'main';
-                const deleteConfirm = await vscode.window.showInformationMessage(
-                    `Worktree "${worktree}" merged into ${merged_into}. Delete the worktree?`,
-                    'Delete Worktree',
-                    'Keep',
-                );
-                if (deleteConfirm === 'Delete Worktree') {
-                    try {
-                        await axios.delete(
-                            `${details.deployUrl}/worktrees/${worktree}`,
-                            { headers: { Authorization: `Bearer ${details.deploySecret}` } },
-                        );
-                        vscode.window.showInformationMessage(`Worktree "${worktree}" deleted.`);
-                    } catch (err: any) {
-                        vscode.window.showErrorMessage(`Failed to delete worktree: ${err.message}`);
-                    }
+                try {
+                    await axios.delete(
+                        `${details.deployUrl}/worktrees/${worktree}`,
+                        { headers: { Authorization: `Bearer ${details.deploySecret}` } },
+                    );
+                    vscode.window.showInformationMessage(`Worktree "${worktree}" merged into ${merged_into} and deleted.`);
+                } catch (err: any) {
+                    vscode.window.showWarningMessage(`Merged into ${merged_into} but failed to delete worktree: ${err.message}`);
                 }
                 await this.loadBusinessProcesses();
             } else if (data.status === 'conflicts') {
@@ -1082,12 +1122,19 @@ export class DashboardPanel {
                 actionsRow.appendChild(filesCard);
 
                 if (bpData.worktree) {
-                    var mergeCard = mkEl('div', 'action-card');
-                    mergeCard.innerHTML = '<div class="card-icon">\\u{1F500}</div><div class="card-label">Merge</div><div class="card-desc">Merge worktree into main</div>';
-                    mergeCard.addEventListener('click', function() {
+                    var syncCard = mkEl('div', 'action-card');
+                    syncCard.innerHTML = '<div class="card-icon">\\u{1F504}</div><div class="card-label">Sync</div><div class="card-desc">Rebase onto main branch</div>';
+                    syncCard.addEventListener('click', function() {
+                        vscodeApi.postMessage({ type: 'syncWorktree', worktree: bpData.worktree });
+                    });
+                    actionsRow.appendChild(syncCard);
+
+                    var mergeDeleteCard = mkEl('div', 'action-card');
+                    mergeDeleteCard.innerHTML = '<div class="card-icon">\\u{1F500}</div><div class="card-label">Merge & Delete</div><div class="card-desc">Merge into main and delete worktree</div>';
+                    mergeDeleteCard.addEventListener('click', function() {
                         vscodeApi.postMessage({ type: 'mergeWorktree', worktree: bpData.worktree });
                     });
-                    actionsRow.appendChild(mergeCard);
+                    actionsRow.appendChild(mergeDeleteCard);
                 }
 
                 actionsSection.appendChild(actionsRow);

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -156,6 +156,15 @@ export class DashboardPanel {
             case 'openTerminal':
                 await this.openPlainTerminal(msg.worktree, msg.bpPath);
                 break;
+            case 'createWorktree':
+                await this.createWorktree();
+                break;
+            case 'createBusinessProcess':
+                await this.createBusinessProcess(msg.worktree);
+                break;
+            case 'createAutomation':
+                await this.createAutomation(msg.worktree, msg.bpPath);
+                break;
         }
     }
 
@@ -184,18 +193,7 @@ export class DashboardPanel {
         this.bpMap.clear();
         const workspaces: { name: string; bps: { key: string; label: string }[] }[] = [];
 
-        if (fs.existsSync(WORKSPACE_DIR)) {
-            const bps = this._findBPsUnder(WORKSPACE_DIR, 4);
-            const bpEntries: { key: string; label: string }[] = [];
-            for (const dirPath of bps) {
-                const rel = path.relative(WORKSPACE_DIR, dirPath);
-                const key = `workspace:${rel}`;
-                bpEntries.push({ key, label: rel });
-                this.bpMap.set(key, dirPath);
-            }
-            workspaces.push({ name: 'Main', bps: bpEntries });
-        }
-
+        // Only show worktrees — no Main tab
         if (fs.existsSync(WORKTREES_DIR)) {
             let wtEntries: fs.Dirent[];
             try { wtEntries = fs.readdirSync(WORKTREES_DIR, { withFileTypes: true }); } catch { wtEntries = []; }
@@ -210,9 +208,8 @@ export class DashboardPanel {
                     bpEntries.push({ key, label: rel });
                     this.bpMap.set(key, dirPath);
                 }
-                if (bpEntries.length > 0) {
-                    workspaces.push({ name: wtEntry.name, bps: bpEntries });
-                }
+                // Always include the worktree even if it has no BPs yet
+                workspaces.push({ name: wtEntry.name, bps: bpEntries });
             }
         }
 
@@ -455,6 +452,83 @@ export class DashboardPanel {
         }
     }
 
+    // ---- Create flows ----
+
+    private async createWorktree(): Promise<void> {
+        const name = await vscode.window.showInputBox({
+            prompt: 'Worktree branch name',
+            placeHolder: 'e.g. feature-login',
+            validateInput: (v) => /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(v) ? null : 'Letters, numbers, hyphens and underscores only',
+        });
+        if (!name) { return; }
+
+        try {
+            // Try GitOps API first
+            const { getDeployDetails } = await import('../deploy_details');
+            const details = await getDeployDetails(this.context);
+            if (details) {
+                const axios = (await import('axios')).default;
+                await axios.post(
+                    `${details.deployUrl}/worktrees/create`,
+                    { branch_name: name },
+                    { headers: { Authorization: `Bearer ${details.deploySecret}` } },
+                );
+            }
+        } catch {
+            // Fallback: create locally
+            const wtPath = path.join(WORKTREES_DIR, name);
+            if (!fs.existsSync(wtPath)) {
+                fs.mkdirSync(wtPath, { recursive: true });
+            }
+        }
+
+        vscode.window.showInformationMessage(`Worktree "${name}" created.`);
+        await this.loadBusinessProcesses();
+    }
+
+    private async createBusinessProcess(worktree: string): Promise<void> {
+        const name = await vscode.window.showInputBox({
+            prompt: 'Business process name',
+            placeHolder: 'e.g. user-management',
+            validateInput: (v) => /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(v) ? null : 'Letters, numbers, hyphens and underscores only',
+        });
+        if (!name) { return; }
+
+        const bpDir = path.join(WORKTREES_DIR, worktree, name);
+        fs.mkdirSync(bpDir, { recursive: true });
+
+        // Create process.toml
+        const processId = require('crypto').randomUUID();
+        fs.writeFileSync(
+            path.join(bpDir, 'process.toml'),
+            `process-id = "${processId}"\n`,
+            'utf-8',
+        );
+
+        // Create README.md
+        fs.writeFileSync(
+            path.join(bpDir, 'README.md'),
+            `# ${name}\n\nDescribe this business process here.\n`,
+            'utf-8',
+        );
+
+        vscode.window.showInformationMessage(`Business process "${name}" created in worktree "${worktree}".`);
+        await this.loadBusinessProcesses();
+    }
+
+    private async createAutomation(worktree: string, bpPath: string): Promise<void> {
+        // Pass relative path from workspace root so the templates gallery
+        // places the new automation in the correct worktree BP directory
+        const relPath = `worktrees/${worktree}/${bpPath}`;
+        const bpDir = path.join(WORKSPACE_DIR, relPath);
+        if (!fs.existsSync(bpDir)) {
+            vscode.window.showErrorMessage(`Business process directory not found: ${bpDir}`);
+            return;
+        }
+
+        vscode.commands.executeCommand('bitswan.openAutomationTemplates', relPath);
+    }
+
     private postMessage(msg: any): void {
         if (!this.disposed) { this.panel.webview.postMessage(msg); }
     }
@@ -588,6 +662,21 @@ export class DashboardPanel {
                 tab.addEventListener('click', function() { currentWsIdx = idx; currentBpKey = ''; bpData = null; renderSubtabs(); renderContent(); });
                 tabBar.appendChild(tab);
             });
+            // "+ New Worktree" tab
+            var addWtTab = document.createElement('div');
+            addWtTab.className = 'tab';
+            addWtTab.textContent = '+';
+            addWtTab.title = 'Create new worktree';
+            addWtTab.style.cssText = 'font-weight:bold; font-size:16px; padding:4px 12px;';
+            addWtTab.addEventListener('click', function() {
+                vscodeApi.postMessage({ type: 'createWorktree' });
+            });
+            tabBar.appendChild(addWtTab);
+        }
+
+        function getActiveWorktree() {
+            var ws = structure[currentWsIdx];
+            return ws ? ws.name : '';
         }
 
         function renderSubtabs() {
@@ -607,6 +696,17 @@ export class DashboardPanel {
                 });
                 subtabBar.appendChild(tab);
             });
+            // "+ New Business Process" subtab
+            var addBpTab = document.createElement('div');
+            addBpTab.className = 'subtab';
+            addBpTab.textContent = '+';
+            addBpTab.title = 'Create new business process';
+            addBpTab.style.cssText = 'font-weight:bold; font-size:14px; padding:4px 12px;';
+            addBpTab.addEventListener('click', function() {
+                vscodeApi.postMessage({ type: 'createBusinessProcess', worktree: getActiveWorktree() });
+            });
+            subtabBar.appendChild(addBpTab);
+
             if (!currentBpKey && ws.bps.length > 0) {
                 currentBpKey = ws.bps[0].key;
                 vscodeApi.postMessage({ type: 'loadBP', key: currentBpKey });
@@ -653,53 +753,67 @@ export class DashboardPanel {
             }
 
             // Automations
-            if (bpData.automations && bpData.automations.length > 0) {
+            {
                 var autoSection = mkEl('div', 'section');
                 autoSection.appendChild(mkEl('div', 'section-title', 'Automations'));
                 var autoCards = mkEl('div', 'auto-cards');
 
-                bpData.automations.forEach(function(auto) {
-                    var card = mkEl('div', 'auto-card');
-                    if (auto.url) {
-                        card.addEventListener('click', function(e) {
-                            if (e.target.tagName === 'BUTTON') return;
-                            vscodeApi.postMessage({ type: 'openUrl', url: auto.url });
-                        });
-                    }
+                if (bpData.automations) {
+                    bpData.automations.forEach(function(auto) {
+                        var card = mkEl('div', 'auto-card');
+                        if (auto.url) {
+                            card.addEventListener('click', function(e) {
+                                if (e.target.tagName === 'BUTTON') return;
+                                vscodeApi.postMessage({ type: 'openUrl', url: auto.url });
+                            });
+                        }
 
-                    var header = mkEl('div', 'auto-card-header');
-                    header.appendChild(mkEl('span', 'auto-card-name', auto.name));
-                    var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
-                    header.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
-                    card.appendChild(header);
+                        var header = mkEl('div', 'auto-card-header');
+                        header.appendChild(mkEl('span', 'auto-card-name', auto.name));
+                        var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
+                        header.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
+                        card.appendChild(header);
 
-                    if (auto.url) {
-                        var urlLine = mkEl('div', '', '');
-                        urlLine.style.cssText = 'font-size:11px; color:var(--vscode-descriptionForeground); margin-bottom:4px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;';
-                        urlLine.textContent = auto.url;
-                        card.appendChild(urlLine);
-                    }
+                        if (auto.url) {
+                            var urlLine = mkEl('div', '', '');
+                            urlLine.style.cssText = 'font-size:11px; color:var(--vscode-descriptionForeground); margin-bottom:4px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;';
+                            urlLine.textContent = auto.url;
+                            card.appendChild(urlLine);
+                        }
 
-                    if (auto.deploymentId) {
-                        var actions = mkEl('div', 'auto-card-actions');
-                        var logsBtn = mkEl('button', 'btn', 'Logs');
-                        logsBtn.addEventListener('click', function(e) {
-                            e.stopPropagation();
-                            vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
-                        });
-                        actions.appendChild(logsBtn);
+                        if (auto.deploymentId) {
+                            var actions = mkEl('div', 'auto-card-actions');
+                            var logsBtn = mkEl('button', 'btn', 'Logs');
+                            logsBtn.addEventListener('click', function(e) {
+                                e.stopPropagation();
+                                vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
+                            });
+                            actions.appendChild(logsBtn);
 
-                        var restartBtn = mkEl('button', 'btn', 'Restart');
-                        restartBtn.addEventListener('click', function(e) {
-                            e.stopPropagation();
-                            vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
-                        });
-                        actions.appendChild(restartBtn);
-                        card.appendChild(actions);
-                    }
+                            var restartBtn = mkEl('button', 'btn', 'Restart');
+                            restartBtn.addEventListener('click', function(e) {
+                                e.stopPropagation();
+                                vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
+                            });
+                            actions.appendChild(restartBtn);
+                            card.appendChild(actions);
+                        }
 
-                    autoCards.appendChild(card);
-                });
+                        autoCards.appendChild(card);
+                    });
+                }
+
+                // "+ New Automation" card
+                if (bpData.worktree) {
+                    var newAutoCard = mkEl('div', 'auto-card');
+                    newAutoCard.style.cssText = 'border-style:dashed; text-align:center; display:flex; align-items:center; justify-content:center; min-height:80px;';
+                    newAutoCard.innerHTML = '<div><div style="font-size:20px; margin-bottom:4px;">+</div><div class="auto-card-name">New Automation</div></div>';
+                    newAutoCard.addEventListener('click', function() {
+                        vscodeApi.postMessage({ type: 'createAutomation', worktree: bpData.worktree, bpPath: bpData.bpPath });
+                    });
+                    autoCards.appendChild(newAutoCard);
+                }
+
                 autoSection.appendChild(autoCards);
                 content.appendChild(autoSection);
             }

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -519,7 +519,7 @@ export class DashboardPanel {
         const terminal = vscode.window.createTerminal(name);
         terminal.show(true);
         // Use source to run the script in the current shell
-        terminal.sendText(`source ${scriptPath}`);
+        terminal.sendText(`source ${scriptPath}; exit`);
 
         // Track active session
         const termName = terminal.name;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -53,15 +53,33 @@ export class DashboardPanel {
     private fileWatcher: vscode.FileSystemWatcher | undefined;
     private currentKey = '';
 
+    private playerJsUri: vscode.Uri | undefined;
+    private playerCssUri: vscode.Uri | undefined;
+
     private constructor(context: vscode.ExtensionContext) {
         this.context = context;
+
+        const asciinemaDir = vscode.Uri.file(
+            path.join(context.extensionPath, 'node_modules', 'asciinema-player', 'dist', 'bundle')
+        );
 
         this.panel = vscode.window.createWebviewPanel(
             'bitswan-workspace',
             'Workspace',
             vscode.ViewColumn.Active,
-            { enableScripts: true, retainContextWhenHidden: true },
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [asciinemaDir],
+            },
         );
+
+        this.playerJsUri = this.panel.webview.asWebviewUri(vscode.Uri.file(
+            path.join(context.extensionPath, 'node_modules', 'asciinema-player', 'dist', 'bundle', 'asciinema-player.min.js')
+        ));
+        this.playerCssUri = this.panel.webview.asWebviewUri(vscode.Uri.file(
+            path.join(context.extensionPath, 'node_modules', 'asciinema-player', 'dist', 'bundle', 'asciinema-player.css')
+        ));
 
         this.panel.webview.html = this._getHtmlForWebview();
 
@@ -799,7 +817,10 @@ export class DashboardPanel {
         .add-root-btn:hover { border-color:var(--vscode-focusBorder); color:var(--vscode-foreground); }
         .keyhints { display:flex; flex-wrap:wrap; gap:12px; padding:6px 16px; border-top:1px solid var(--border); flex-shrink:0; font-size:11px; color:var(--vscode-descriptionForeground); }
         .keyhints kbd { padding:1px 5px; border:1px solid var(--vscode-editorWidget-border, rgba(128,128,128,0.4)); border-radius:3px; font-size:10px; font-family:inherit; background:var(--vscode-sideBar-background, rgba(128,128,128,0.1)); }
+        #playerWrapper { min-height:400px; }
+        #playerWrapper .ap-wrapper { width:100% !important; }
     </style>
+    <link rel="stylesheet" type="text/css" href="${this.playerCssUri}" />
 </head>
 <body>
     <div class="header"><h2>Workspace</h2></div>
@@ -1284,7 +1305,20 @@ export class DashboardPanel {
                     var area = document.getElementById('playbackArea');
                     if (area && msg.data) {
                         area.style.display = 'block';
-                        area.innerHTML = '<pre style="margin:0; padding:12px; max-height:400px; overflow:auto; color:#0f0; font-size:11px; line-height:1.3; white-space:pre-wrap;">' + msg.data.replace(/</g, '&lt;') + '</pre>';
+                        area.innerHTML = '<div style="display:flex; align-items:center; gap:8px; padding:8px 12px; border-bottom:1px solid var(--border); background:var(--vscode-sideBar-background);"><button class="btn btn-sm" id="closePlayer">Back</button><span style="font-size:11px; color:var(--vscode-descriptionForeground);">' + (msg.castFile || 'Playback') + '</span></div><div id="playerWrapper"></div>';
+                        document.getElementById('closePlayer').addEventListener('click', function() {
+                            area.style.display = 'none';
+                            area.innerHTML = '';
+                        });
+                        try {
+                            AsciinemaPlayer.create(
+                                { data: msg.data },
+                                document.getElementById('playerWrapper'),
+                                { autoPlay: true, terminalFontSize: '13px' }
+                            );
+                        } catch (err) {
+                            document.getElementById('playerWrapper').textContent = 'Player error: ' + String(err);
+                        }
                     }
                     break;
             }
@@ -1292,6 +1326,7 @@ export class DashboardPanel {
 
         vscodeApi.postMessage({ type: 'ready' });
     </script>
+    <script src="${this.playerJsUri}"></script>
 </body>
 </html>
         `;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -503,8 +503,9 @@ export class DashboardPanel {
         const terminal = vscode.window.createTerminal(name);
         terminal.show(true);
 
-        // Build the export + exec ssh command.
-        // SSH_AUTO_CMD is base64-encoded to avoid shell metachar interpretation.
+        // SSH_AUTO_CMD is base64-encoded to avoid shell metachar issues.
+        // Also send the command via sendText as fallback for older containers
+        // that don't support SSH_AUTO_CMD yet.
         let exportVars = `export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}"`;
         if (autoCmd) {
             const b64 = Buffer.from(autoCmd).toString('base64');

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -441,113 +441,118 @@ export class DashboardPanel {
 
     // ---- Terminals ----
 
+    /**
+     * Ensure the coding agent container is running, auto-starting it if needed.
+     * Returns the agent hostname, or null if it couldn't be started.
+     */
+    private async ensureAgentRunning(): Promise<string | null> {
+        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
+        const agentHost = `${workspaceName}-coding-agent`;
+
+        const isReachable = () => new Promise<boolean>(resolve => {
+            cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
+        });
+
+        if (await isReachable()) { return agentHost; }
+
+        const started = await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Starting coding agent container...',
+            cancellable: false,
+        }, async (progress) => {
+            const { getDeployDetails } = await import('../deploy_details');
+            const details = await getDeployDetails(this.context);
+            if (!details) { return false; }
+            try {
+                const axios = (await import('axios')).default;
+                await axios.post(
+                    `${details.deployUrl}/worktrees/coding-agent/ensure`,
+                    {},
+                    { headers: { Authorization: `Bearer ${details.deploySecret}` }, timeout: 120000 },
+                );
+            } catch (err: any) {
+                vscode.window.showErrorMessage(`Failed to start coding agent: ${err?.response?.data?.detail || err?.message}`);
+                return false;
+            }
+            progress.report({ message: 'Waiting for SSH to become ready...' });
+            for (let i = 0; i < 15; i++) {
+                await new Promise(r => setTimeout(r, 2000));
+                if (await isReachable()) { return true; }
+            }
+            vscode.window.showErrorMessage('Coding agent started but SSH is not reachable yet.');
+            return false;
+        });
+
+        return started ? agentHost : null;
+    }
+
+    /**
+     * Open an SSH terminal to the coding agent container.
+     * @param name - Terminal tab name
+     * @param worktree - Worktree name
+     * @param autoCmd - Command to run on the remote (via SSH_AUTO_CMD). If empty, drops to shell.
+     */
+    private async openSSHTerminal(name: string, worktree: string, autoCmd: string): Promise<vscode.Terminal | null> {
+        const agentHost = await this.ensureAgentRunning();
+        if (!agentHost) { return null; }
+
+        const userEmail = await getUserEmail(this.context) || 'unknown';
+        const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
+        const logged = anon ? 'false' : 'true';
+
+        const terminal = vscode.window.createTerminal(name);
+        terminal.show(true);
+
+        // Build the export + exec ssh command.
+        // SSH_AUTO_CMD is base64-encoded to avoid shell metachar interpretation.
+        let exportVars = `export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}"`;
+        if (autoCmd) {
+            const b64 = Buffer.from(autoCmd).toString('base64');
+            exportVars += ` SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`;
+        }
+        terminal.sendText(`${exportVars} && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+
+        // Track active session
+        const termName = terminal.name;
+        activeSessions.push({ worktree, userEmail, terminalName: termName });
+        this.sendActiveSessions();
+
+        const disposable = vscode.window.onDidCloseTerminal(t => {
+            if (t.name === termName) {
+                const idx = activeSessions.findIndex(s => s.terminalName === termName);
+                if (idx >= 0) { activeSessions.splice(idx, 1); }
+                if (DashboardPanel.currentPanel) {
+                    DashboardPanel.currentPanel.sendActiveSessions();
+                    DashboardPanel.currentPanel._reloadCurrentKey();
+                }
+                disposable.dispose();
+            }
+        });
+
+        // Refresh sessions after meta.json is created by the agent container
+        setTimeout(() => this._reloadCurrentKey(), 5000);
+        return terminal;
+    }
+
     private async openCodingAgentTerminal(worktree: string, bpPath: string): Promise<void> {
         if (worktree) {
-            // Worktree: SSH into coding agent container
-            const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
-            const agentHost = `${workspaceName}-coding-agent`;
-
-            const reachable = await new Promise<boolean>(resolve => {
-                cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
-            });
-
-            if (!reachable) {
-                vscode.window.showErrorMessage('Coding agent container is not running. Start it from the worktrees view.');
-                return;
-            }
-
-            const userEmail = await getUserEmail(this.context) || 'unknown';
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
-
-            const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
-            const logged = anon ? 'false' : 'true';
             const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
-            const autoCmdB64 = Buffer.from(autoCmd).toString('base64');
-            const terminal = vscode.window.createTerminal(`Claude: ${worktree}/${bpPath}`);
-            terminal.show(true);
-            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="$(echo ${autoCmdB64} | base64 -d)" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
-
-            const termName = terminal.name;
-            activeSessions.push({ worktree, userEmail, terminalName: termName });
-            this.sendActiveSessions();
-
-            const disposable = vscode.window.onDidCloseTerminal(t => {
-                if (t.name === termName) {
-                    const idx = activeSessions.findIndex(s => s.terminalName === termName);
-                    if (idx >= 0) { activeSessions.splice(idx, 1); }
-                    if (DashboardPanel.currentPanel) {
-                        DashboardPanel.currentPanel.sendActiveSessions();
-                        DashboardPanel.currentPanel._reloadCurrentKey();
-                    }
-                    disposable.dispose();
-                }
-            });
-
-            // Refresh sessions after meta.json is created by the agent container
-            setTimeout(() => this._reloadCurrentKey(), 5000);
+            await this.openSSHTerminal(`Claude: ${worktree}/${bpPath}`, worktree, autoCmd);
         } else {
-            // Main workspace: local terminal
             const cdPath = path.join(WORKSPACE_DIR, bpPath);
-            const terminal = vscode.window.createTerminal({
-                name: `Claude: ${bpPath}`,
-                cwd: cdPath,
-            });
+            const terminal = vscode.window.createTerminal({ name: `Claude: ${bpPath}`, cwd: cdPath });
             terminal.show(true);
-            terminal.sendText('mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions');
+            terminal.sendText(`mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`);
         }
     }
 
     private async openPlainTerminal(worktree: string, bpPath: string): Promise<void> {
         if (worktree) {
-            const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
-            const agentHost = `${workspaceName}-coding-agent`;
-
-            const reachable = await new Promise<boolean>(resolve => {
-                cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
-            });
-
-            if (!reachable) {
-                vscode.window.showErrorMessage('Coding agent container is not running.');
-                return;
-            }
-
-            const userEmail = await getUserEmail(this.context) || 'unknown';
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
-
-            const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
-            const logged = anon ? 'false' : 'true';
-            const autoCmd = `cd ${cdPath} && exec bash`;
-            const autoCmdB64 = Buffer.from(autoCmd).toString('base64');
-            const terminal = vscode.window.createTerminal(`Terminal: ${worktree}/${bpPath}`);
-            terminal.show(true);
-            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="$(echo ${autoCmdB64} | base64 -d)" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
-
-            const termName = terminal.name;
-            activeSessions.push({ worktree, userEmail, terminalName: termName });
-            this.sendActiveSessions();
-            const disposable = vscode.window.onDidCloseTerminal(t => {
-                if (t.name === termName) {
-                    const idx = activeSessions.findIndex(s => s.terminalName === termName);
-                    if (idx >= 0) { activeSessions.splice(idx, 1); }
-                    if (DashboardPanel.currentPanel) {
-                        DashboardPanel.currentPanel.sendActiveSessions();
-                        DashboardPanel.currentPanel._reloadCurrentKey();
-                    }
-                    disposable.dispose();
-                }
-            });
-
-            setTimeout(() => {
-                terminal.sendText(`cd "${cdPath}"`);
-            }, 2000);
-
-            setTimeout(() => this._reloadCurrentKey(), 5000);
+            await this.openSSHTerminal(`Terminal: ${worktree}/${bpPath}`, worktree, `cd ${cdPath} && exec bash`);
         } else {
-            const cdPath = path.join(WORKSPACE_DIR, bpPath);
-            const terminal = vscode.window.createTerminal({
-                name: `Terminal: ${bpPath}`,
-                cwd: cdPath,
-            });
+            const terminal = vscode.window.createTerminal({ name: `Terminal: ${bpPath}`, cwd: path.join(WORKSPACE_DIR, bpPath) });
             terminal.show(true);
         }
     }
@@ -703,21 +708,7 @@ export class DashboardPanel {
     }
 
     private async launchMergeConflictAgent(worktree: string, conflictedFiles: string[]): Promise<void> {
-        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
-        const agentHost = `${workspaceName}-coding-agent`;
-
-        const reachable = await new Promise<boolean>(resolve => {
-            cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
-        });
-
-        if (!reachable) {
-            vscode.window.showErrorMessage('Coding agent container is not running.');
-            return;
-        }
-
-        const userEmail = await getUserEmail(this.context) || 'unknown';
         const wtPath = `/workspace/worktrees/${worktree}`;
-
         const conflictList = conflictedFiles.map(f => `  - ${f}`).join('\n');
         const claudePrompt = [
             `A rebase-and-merge is in progress for worktree "${worktree}" and there are conflicts.`,
@@ -732,11 +723,8 @@ export class DashboardPanel {
             `4. Once the merge is complete, tell the user it's done`,
         ].join('\\n');
 
-        const mergeAutoCmd = `cd ${wtPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
-        const mergeB64 = Buffer.from(mergeAutoCmd).toString('base64');
-        const terminal = vscode.window.createTerminal(`Merge: ${worktree}`);
-        terminal.show(true);
-        terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="true" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="$(echo ${mergeB64} | base64 -d)" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+        const autoCmd = `cd ${wtPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
+        await this.openSSHTerminal(`Merge: ${worktree}`, worktree, autoCmd);
     }
 
     private sendActiveSessions(): void {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -1,0 +1,903 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as cp from 'child_process';
+import * as toml from '@iarna/toml';
+import { getUserEmail } from '../services/user_info';
+
+const REQUIREMENTS_FILENAME = 'testable-requirements.toml';
+const WORKSPACE_DIR = '/workspace/workspace';
+const WORKTREES_DIR = '/workspace/workspace/worktrees';
+
+interface Requirement {
+    id: string;
+    description: string;
+    status: 'pass' | 'fail' | 'pending' | 'retest' | 'proposed';
+    parent: string;
+}
+
+interface AutomationInfo {
+    name: string;
+    deploymentId: string;
+    state: string;
+    url: string;
+    relativePath: string;
+}
+
+function parseRequirementsToml(content: string): Requirement[] {
+    try {
+        const data = toml.parse(content) as any;
+        const raw: any[] = data.requirement || [];
+        return raw.map(r => ({
+            id: String(r.id || ''),
+            description: String(r.description || ''),
+            status: (r.status as any) || 'pending',
+            parent: String(r.parent || ''),
+        }));
+    } catch { return []; }
+}
+
+function serializeRequirementsToml(reqs: Requirement[]): string {
+    const data = { requirement: reqs.map(r => ({ id: r.id, parent: r.parent, description: r.description, status: r.status })) };
+    return toml.stringify(data as any);
+}
+
+export class DashboardPanel {
+    private static currentPanel: DashboardPanel | undefined;
+
+    private readonly panel: vscode.WebviewPanel;
+    private readonly context: vscode.ExtensionContext;
+    private disposed = false;
+    private bpMap = new Map<string, string>();
+    private fileWatcher: vscode.FileSystemWatcher | undefined;
+    private currentKey = '';
+
+    private constructor(context: vscode.ExtensionContext) {
+        this.context = context;
+
+        this.panel = vscode.window.createWebviewPanel(
+            'bitswan-dashboard',
+            'Dashboard',
+            vscode.ViewColumn.Active,
+            { enableScripts: true, retainContextWhenHidden: true },
+        );
+
+        this.panel.webview.html = this._getHtmlForWebview();
+
+        this.panel.webview.onDidReceiveMessage(
+            (msg) => this.onMessage(msg),
+            undefined,
+            context.subscriptions,
+        );
+
+        this.fileWatcher = vscode.workspace.createFileSystemWatcher('**/testable-requirements.toml');
+        this.fileWatcher.onDidChange(() => this._reloadCurrentKey());
+        this.fileWatcher.onDidCreate(() => this._reloadCurrentKey());
+
+        this.panel.onDidDispose(() => {
+            this.disposed = true;
+            if (this.fileWatcher) { this.fileWatcher.dispose(); }
+            DashboardPanel.currentPanel = undefined;
+        });
+    }
+
+    public static createOrShow(context: vscode.ExtensionContext): void {
+        if (DashboardPanel.currentPanel && !DashboardPanel.currentPanel.disposed) {
+            DashboardPanel.currentPanel.panel.reveal(vscode.ViewColumn.Active);
+            return;
+        }
+        DashboardPanel.currentPanel = new DashboardPanel(context);
+    }
+
+    private async onMessage(msg: any): Promise<void> {
+        if (!msg || !msg.type) { return; }
+        switch (msg.type) {
+            case 'ready':
+                await this.loadBusinessProcesses();
+                break;
+            case 'loadBP':
+                await this.loadBPContent(msg.key);
+                break;
+            case 'addRequirement':
+                await this.addRequirement(msg.key, msg.requirement);
+                break;
+            case 'updateRequirement':
+                await this.updateRequirement(msg.key, msg.requirement);
+                break;
+            case 'deleteRequirement':
+                await this.deleteRequirement(msg.key, msg.requirementId);
+                break;
+            case 'openUrl':
+                if (msg.url) {
+                    vscode.env.openExternal(vscode.Uri.parse(msg.url));
+                }
+                break;
+            case 'showLogs':
+                if (msg.deploymentId) {
+                    // Find the automation and trigger log viewer
+                    const automations = this.context.globalState.get<any[]>('automations', []);
+                    const automation = automations?.find(a =>
+                        (a.deployment_id || a.deploymentId) === msg.deploymentId
+                    );
+                    if (automation) {
+                        vscode.commands.executeCommand('bitswan.showAutomationLogs', {
+                            name: automation.name || automation.deployment_id,
+                            deploymentId: automation.deployment_id || automation.deploymentId,
+                            automationUrl: automation.automation_url || automation.automationUrl,
+                        });
+                    }
+                }
+                break;
+            case 'restartAutomation':
+                if (msg.deploymentId) {
+                    const activeInstance = this.context.globalState.get<any>('activeGitOpsInstance');
+                    if (activeInstance) {
+                        const automations = this.context.globalState.get<any[]>('automations', []);
+                        const auto = automations?.find(a =>
+                            (a.deployment_id || a.deploymentId) === msg.deploymentId
+                        );
+                        if (auto) {
+                            const name = auto.name || auto.deployment_id;
+                            try {
+                                const { restartAutomation } = await import('../lib');
+                                const url = `${activeInstance.url}/automations/${name}/restart`;
+                                await restartAutomation(url, activeInstance.secret);
+                                vscode.window.showInformationMessage(`Restarted ${name}`);
+                            } catch (err: any) {
+                                vscode.window.showErrorMessage(`Failed to restart: ${err.message}`);
+                            }
+                        }
+                    }
+                }
+                break;
+            case 'openCodingAgent':
+                await this.openCodingAgentTerminal(msg.worktree, msg.bpPath);
+                break;
+            case 'openTerminal':
+                await this.openPlainTerminal(msg.worktree, msg.bpPath);
+                break;
+        }
+    }
+
+    // ---- Discovery ----
+
+    private _findBPsUnder(root: string, maxDepth: number): string[] {
+        const results: string[] = [];
+        const walk = (dir: string, depth: number) => {
+            if (depth > maxDepth) { return; }
+            let entries: fs.Dirent[];
+            try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+            for (const entry of entries) {
+                if (!entry.isDirectory() || entry.name.startsWith('.')) { continue; }
+                const fullPath = path.join(dir, entry.name);
+                if (fs.existsSync(path.join(fullPath, 'process.toml'))) {
+                    results.push(fullPath);
+                }
+                walk(fullPath, depth + 1);
+            }
+        };
+        walk(root, 0);
+        return results;
+    }
+
+    private async loadBusinessProcesses(): Promise<void> {
+        this.bpMap.clear();
+        const workspaces: { name: string; bps: { key: string; label: string }[] }[] = [];
+
+        if (fs.existsSync(WORKSPACE_DIR)) {
+            const bps = this._findBPsUnder(WORKSPACE_DIR, 4);
+            const bpEntries: { key: string; label: string }[] = [];
+            for (const dirPath of bps) {
+                const rel = path.relative(WORKSPACE_DIR, dirPath);
+                const key = `workspace:${rel}`;
+                bpEntries.push({ key, label: rel });
+                this.bpMap.set(key, dirPath);
+            }
+            workspaces.push({ name: 'Main', bps: bpEntries });
+        }
+
+        if (fs.existsSync(WORKTREES_DIR)) {
+            let wtEntries: fs.Dirent[];
+            try { wtEntries = fs.readdirSync(WORKTREES_DIR, { withFileTypes: true }); } catch { wtEntries = []; }
+            for (const wtEntry of wtEntries) {
+                if (!wtEntry.isDirectory() || wtEntry.name.startsWith('.') || wtEntry.name === 'worktrees') { continue; }
+                const wtPath = path.join(WORKTREES_DIR, wtEntry.name);
+                const bps = this._findBPsUnder(wtPath, 4);
+                const bpEntries: { key: string; label: string }[] = [];
+                for (const dirPath of bps) {
+                    const rel = path.relative(wtPath, dirPath);
+                    const key = `worktree:${wtEntry.name}:${rel}`;
+                    bpEntries.push({ key, label: rel });
+                    this.bpMap.set(key, dirPath);
+                }
+                if (bpEntries.length > 0) {
+                    workspaces.push({ name: wtEntry.name, bps: bpEntries });
+                }
+            }
+        }
+
+        this.postMessage({ type: 'structure', workspaces });
+    }
+
+    // ---- Load BP content ----
+
+    private async loadBPContent(key: string): Promise<void> {
+        this.currentKey = key;
+        const dirPath = this.bpMap.get(key);
+        if (!dirPath) {
+            this.postMessage({ type: 'bpContent', key, requirements: [], automations: [], readme: '', worktree: '', bpPath: '' });
+            return;
+        }
+
+        // Requirements
+        const requirements = this._readLocalReqs(dirPath);
+
+        // README
+        let readme = '';
+        const readmePath = path.join(dirPath, 'README.md');
+        if (fs.existsSync(readmePath)) {
+            try { readme = fs.readFileSync(readmePath, 'utf-8'); } catch { /* */ }
+        }
+
+        // Automations — match by relative_path
+        const allAutomations = this.context.globalState.get<any[]>('automations', []);
+        const automations: AutomationInfo[] = [];
+
+        // Find automation dirs under this BP
+        const automationDirs = this._findAutomationDirsUnder(dirPath);
+        for (const autoDir of automationDirs) {
+            const autoName = path.basename(autoDir);
+            const relFromWorkspace = path.relative(WORKSPACE_DIR, autoDir);
+            // Find matching automation from global state
+            const match = allAutomations?.find(a => {
+                const aPath = a.relative_path || a.relativePath || '';
+                return aPath === relFromWorkspace || aPath.endsWith('/' + relFromWorkspace);
+            });
+            automations.push({
+                name: autoName,
+                deploymentId: match ? (match.deployment_id || match.deploymentId || '') : '',
+                state: match ? (match.state || 'not deployed') : 'not deployed',
+                url: match ? (match.automation_url || match.automationUrl || '') : '',
+                relativePath: relFromWorkspace,
+            });
+        }
+
+        // Parse key to get worktree and bpPath
+        let worktree = '';
+        let bpPath = '';
+        if (key.startsWith('worktree:')) {
+            const parts = key.split(':');
+            worktree = parts[1] || '';
+            bpPath = parts.slice(2).join(':');
+        } else if (key.startsWith('workspace:')) {
+            bpPath = key.substring('workspace:'.length);
+        }
+
+        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath });
+    }
+
+    private _findAutomationDirsUnder(bpDir: string): string[] {
+        const results: string[] = [];
+        const walk = (dir: string, depth: number) => {
+            if (depth > 3) { return; }
+            let entries: fs.Dirent[];
+            try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+            for (const entry of entries) {
+                if (!entry.isDirectory() || entry.name.startsWith('.') || entry.name === 'image') { continue; }
+                const fullPath = path.join(dir, entry.name);
+                if (fs.existsSync(path.join(fullPath, 'automation.toml'))) {
+                    results.push(fullPath);
+                }
+                walk(fullPath, depth + 1);
+            }
+        };
+        walk(bpDir, 0);
+        return results;
+    }
+
+    // ---- File I/O ----
+
+    private _readLocalReqs(dirPath: string): Requirement[] {
+        const filePath = path.join(dirPath, REQUIREMENTS_FILENAME);
+        if (!fs.existsSync(filePath)) { return []; }
+        try { return parseRequirementsToml(fs.readFileSync(filePath, 'utf-8')); }
+        catch { return []; }
+    }
+
+    private _writeLocalReqs(dirPath: string, reqs: Requirement[]): void {
+        fs.writeFileSync(path.join(dirPath, REQUIREMENTS_FILENAME), serializeRequirementsToml(reqs), 'utf-8');
+    }
+
+    // ---- Requirements CRUD ----
+
+    private async addRequirement(key: string, requirement: Omit<Requirement, 'id'>): Promise<void> {
+        const dirPath = this.bpMap.get(key);
+        if (!dirPath) { return; }
+        const existing = this._readLocalReqs(dirPath);
+        const maxNum = existing.reduce((max, r) => {
+            const m = r.id.match(/\d+$/);
+            return m ? Math.max(max, parseInt(m[0], 10)) : max;
+        }, 0);
+        const prefix = requirement.status === 'proposed' ? 'AI-' : 'REQ-';
+        const newId = prefix + (maxNum + 1).toString().padStart(3, '0');
+        existing.push({ id: newId, ...requirement } as Requirement);
+        this._writeLocalReqs(dirPath, existing);
+        await this.loadBPContent(key);
+    }
+
+    private async updateRequirement(key: string, requirement: Requirement): Promise<void> {
+        const dirPath = this.bpMap.get(key);
+        if (!dirPath || !requirement?.id) { return; }
+        const existing = this._readLocalReqs(dirPath);
+        const idx = existing.findIndex(r => r.id === requirement.id);
+        if (idx >= 0) {
+            existing[idx] = requirement;
+            this._writeLocalReqs(dirPath, existing);
+        }
+        await this.loadBPContent(key);
+    }
+
+    private async deleteRequirement(key: string, requirementId: string): Promise<void> {
+        if (!key || !requirementId) { return; }
+        const confirmation = await vscode.window.showWarningMessage(
+            `Delete requirement "${requirementId}"?`, { modal: true }, 'Delete'
+        );
+        if (confirmation !== 'Delete') { return; }
+        const dirPath = this.bpMap.get(key);
+        if (!dirPath) { return; }
+        const filtered = this._readLocalReqs(dirPath).filter(r => r.id !== requirementId);
+        this._writeLocalReqs(dirPath, filtered);
+        await this.loadBPContent(key);
+    }
+
+    private _reloadCurrentKey(): void {
+        if (!this.disposed && this.currentKey) {
+            this.loadBPContent(this.currentKey);
+        }
+    }
+
+    // ---- Terminals ----
+
+    private async openCodingAgentTerminal(worktree: string, bpPath: string): Promise<void> {
+        if (!worktree) {
+            vscode.window.showErrorMessage('Coding agent is only available for worktrees.');
+            return;
+        }
+
+        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
+        const agentHost = `${workspaceName}-coding-agent`;
+
+        // Check if agent container is reachable
+        const reachable = await new Promise<boolean>(resolve => {
+            cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
+        });
+
+        if (!reachable) {
+            vscode.window.showErrorMessage('Coding agent container is not running. Start it from the worktrees view.');
+            return;
+        }
+
+        const userEmail = await getUserEmail(this.context);
+        const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
+
+        const terminal = vscode.window.createTerminal({
+            name: `Claude: ${worktree}/${bpPath}`,
+            shellPath: '/usr/bin/ssh',
+            shellArgs: [
+                '-i', '/workspace/.ssh/id_ed25519',
+                '-o', 'StrictHostKeyChecking=no',
+                '-o', 'UserKnownHostsFile=/dev/null',
+                '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
+                `agent@${agentHost}`,
+            ],
+            env: {
+                SSH_USER_EMAIL: userEmail,
+                SSH_LOGGED: 'true',
+                SSH_WORKTREE: worktree,
+            },
+        });
+        terminal.show(true);
+
+        // After SSH connects, cd and launch claude
+        setTimeout(() => {
+            terminal.sendText(`cd "${cdPath}" && claude --dangerously-skip-permissions`);
+        }, 2000);
+    }
+
+    private async openPlainTerminal(worktree: string, bpPath: string): Promise<void> {
+        if (!worktree) {
+            vscode.window.showErrorMessage('Terminal is only available for worktrees.');
+            return;
+        }
+
+        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
+        const agentHost = `${workspaceName}-coding-agent`;
+
+        const reachable = await new Promise<boolean>(resolve => {
+            cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
+        });
+
+        if (!reachable) {
+            vscode.window.showErrorMessage('Coding agent container is not running.');
+            return;
+        }
+
+        const userEmail = await getUserEmail(this.context);
+        const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
+
+        const terminal = vscode.window.createTerminal({
+            name: `Terminal: ${worktree}/${bpPath}`,
+            shellPath: '/usr/bin/ssh',
+            shellArgs: [
+                '-i', '/workspace/.ssh/id_ed25519',
+                '-o', 'StrictHostKeyChecking=no',
+                '-o', 'UserKnownHostsFile=/dev/null',
+                '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
+                `agent@${agentHost}`,
+            ],
+            env: {
+                SSH_USER_EMAIL: userEmail,
+                SSH_LOGGED: 'false',
+                SSH_WORKTREE: worktree,
+            },
+        });
+        terminal.show(true);
+
+        setTimeout(() => {
+            terminal.sendText(`cd "${cdPath}"`);
+        }, 2000);
+    }
+
+    private postMessage(msg: any): void {
+        if (!this.disposed) { this.panel.webview.postMessage(msg); }
+    }
+
+    // ---- HTML ----
+
+    private _getHtmlForWebview(): string {
+        return /* html */`
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        :root { color-scheme: light dark; font-family: var(--vscode-font-family, sans-serif);
+            --status-pass: #3fb950; --status-fail: #f85149; --status-pending: #d29922; --status-retest: #a371f7; --status-proposed: #768390; --border: var(--vscode-editorWidget-border, rgba(128,128,128,0.3)); }
+        * { box-sizing: border-box; }
+        body { margin:0; padding:0; font-size:13px; color:var(--vscode-foreground); background:var(--vscode-editor-background); display:flex; flex-direction:column; height:100vh; overflow:hidden; }
+        .header { display:flex; align-items:center; gap:12px; padding:12px 16px; border-bottom:1px solid var(--border); flex-shrink:0; }
+        .header h2 { margin:0; font-size:16px; }
+        .tab-bar { display:flex; border-bottom:2px solid var(--border); flex-shrink:0; padding:0 8px; }
+        .tab { padding:8px 16px; cursor:pointer; font-size:12px; font-weight:500; border-bottom:2px solid transparent; margin-bottom:-2px; color:var(--vscode-descriptionForeground); }
+        .tab:hover { color:var(--vscode-foreground); }
+        .tab.active { color:var(--vscode-foreground); border-bottom-color:var(--vscode-focusBorder, #007acc); }
+        .subtab-bar { display:flex; border-bottom:1px solid var(--border); flex-shrink:0; padding:0 8px; background:var(--vscode-sideBar-background, rgba(128,128,128,0.05)); }
+        .subtab { padding:6px 14px; cursor:pointer; font-size:11px; border-bottom:2px solid transparent; margin-bottom:-1px; color:var(--vscode-descriptionForeground); }
+        .subtab:hover { color:var(--vscode-foreground); }
+        .subtab.active { color:var(--vscode-foreground); border-bottom-color:var(--vscode-focusBorder, #007acc); }
+        .content { flex:1; overflow-y:auto; padding:12px 16px; }
+        .placeholder { padding:32px 16px; text-align:center; color:var(--vscode-descriptionForeground); }
+
+        /* Sections */
+        .section { margin-bottom:20px; }
+        .section-title { font-size:13px; font-weight:600; margin-bottom:8px; color:var(--vscode-descriptionForeground); text-transform:uppercase; letter-spacing:0.5px; }
+
+        /* Action cards row */
+        .action-cards { display:flex; gap:10px; flex-wrap:wrap; }
+        .action-card { flex:1; min-width:140px; padding:16px; border:1px solid var(--border); border-radius:8px; cursor:pointer; text-align:center; transition: border-color 0.15s; }
+        .action-card:hover { border-color:var(--vscode-focusBorder, #007acc); }
+        .action-card .card-icon { font-size:24px; margin-bottom:6px; }
+        .action-card .card-label { font-size:12px; font-weight:600; }
+        .action-card .card-desc { font-size:11px; color:var(--vscode-descriptionForeground); margin-top:2px; }
+
+        /* Automation cards */
+        .auto-cards { display:flex; gap:10px; flex-wrap:wrap; }
+        .auto-card { flex:1; min-width:200px; max-width:350px; padding:12px; border:1px solid var(--border); border-radius:8px; cursor:pointer; transition: border-color 0.15s; }
+        .auto-card:hover { border-color:var(--vscode-focusBorder, #007acc); }
+        .auto-card-header { display:flex; align-items:center; gap:8px; margin-bottom:6px; }
+        .auto-card-name { font-weight:600; font-size:13px; }
+        .auto-card-state { font-size:10px; padding:2px 6px; border-radius:8px; text-transform:uppercase; font-weight:600; }
+        .auto-card-state.running { background:var(--status-pass); color:#fff; }
+        .auto-card-state.exited, .auto-card-state.dead { background:var(--status-fail); color:#fff; }
+        .auto-card-state.not-deployed { background:var(--status-proposed); color:#fff; }
+        .auto-card-actions { display:flex; gap:6px; margin-top:8px; }
+
+        /* Buttons */
+        .btn { padding:4px 10px; border:1px solid var(--vscode-button-border, transparent); border-radius:4px; background:var(--vscode-button-secondaryBackground, rgba(128,128,128,0.2)); color:var(--vscode-button-secondaryForeground, var(--vscode-foreground)); cursor:pointer; font-size:11px; }
+        .btn:hover { opacity:0.85; }
+        .btn-primary { background:var(--vscode-button-background); color:var(--vscode-button-foreground); }
+        .btn-ghost { background:transparent; color:var(--vscode-descriptionForeground); border:none; }
+        .btn-ghost:hover { background:var(--status-fail); color:#fff; }
+
+        /* README */
+        .readme { padding:12px; border:1px solid var(--border); border-radius:8px; background:var(--vscode-sideBar-background, rgba(128,128,128,0.05)); font-size:12px; line-height:1.5; white-space:pre-wrap; max-height:200px; overflow-y:auto; }
+
+        /* Requirements (from original) */
+        .req-node { margin-bottom:6px; position:relative; }
+        .req-card { border:1px solid var(--vscode-editorWidget-border, rgba(128,128,128,0.25)); border-radius:6px; padding:8px 12px; background:var(--vscode-editor-background); position:relative; outline:none; }
+        .req-card:hover, .req-card:focus { border-color:var(--vscode-focusBorder, rgba(128,128,128,0.5)); }
+        .req-card:focus { box-shadow:0 0 0 1px var(--vscode-focusBorder, #007acc); }
+        .req-card-header { display:flex; align-items:center; gap:8px; }
+        .req-id { font-weight:600; font-size:11px; color:var(--vscode-descriptionForeground); }
+        .status-badge { display:inline-block; padding:1px 8px; border-radius:10px; font-size:10px; font-weight:600; text-transform:uppercase; cursor:pointer; user-select:none; }
+        .status-badge.pass { background:var(--status-pass); color:#fff; }
+        .status-badge.fail { background:var(--status-fail); color:#fff; }
+        .status-badge.pending { background:var(--status-pending); color:#fff; }
+        .status-badge.retest { background:var(--status-retest); color:#fff; }
+        .status-badge.proposed { background:var(--status-proposed); color:#fff; font-style:italic; }
+        .req-desc { font-size:12px; line-height:1.4; white-space:pre-wrap; cursor:text; padding:4px 0 2px; min-height:16px; }
+        .req-desc:hover { background:var(--vscode-list-hoverBackground, rgba(128,128,128,0.08)); border-radius:4px; }
+        .req-desc textarea { width:100%; min-height:40px; padding:4px 6px; background:var(--vscode-input-background); color:var(--vscode-input-foreground); border:1px solid var(--vscode-focusBorder); border-radius:4px; font-size:12px; font-family:inherit; resize:vertical; }
+        .req-actions { display:flex; gap:6px; align-items:center; margin-left:auto; }
+        .req-children { margin-left:20px; margin-top:4px; }
+        .add-child-btn { display:block; margin:4px auto 0; padding:1px 12px; border:1px dashed var(--vscode-editorWidget-border, rgba(128,128,128,0.4)); border-radius:4px; background:transparent; color:var(--vscode-descriptionForeground); cursor:pointer; font-size:11px; }
+        .add-child-btn:hover { border-color:var(--vscode-focusBorder); color:var(--vscode-foreground); }
+        .add-root-btn { display:block; margin:8px auto; padding:4px 16px; border:1px dashed var(--vscode-editorWidget-border, rgba(128,128,128,0.4)); border-radius:6px; background:transparent; color:var(--vscode-descriptionForeground); cursor:pointer; font-size:12px; }
+        .add-root-btn:hover { border-color:var(--vscode-focusBorder); color:var(--vscode-foreground); }
+        .keyhints { display:flex; flex-wrap:wrap; gap:12px; padding:6px 16px; border-top:1px solid var(--border); flex-shrink:0; font-size:11px; color:var(--vscode-descriptionForeground); }
+        .keyhints kbd { padding:1px 5px; border:1px solid var(--vscode-editorWidget-border, rgba(128,128,128,0.4)); border-radius:3px; font-size:10px; font-family:inherit; background:var(--vscode-sideBar-background, rgba(128,128,128,0.1)); }
+    </style>
+</head>
+<body>
+    <div class="header"><h2>Dashboard</h2></div>
+    <div class="tab-bar" id="tabBar"></div>
+    <div class="subtab-bar" id="subtabBar"></div>
+    <div class="content" id="content">
+        <div class="placeholder" id="placeholder">Loading...</div>
+    </div>
+    <div class="keyhints" id="keyhints"></div>
+    <script>
+        var vscodeApi = acquireVsCodeApi();
+        var tabBar = document.getElementById('tabBar');
+        var subtabBar = document.getElementById('subtabBar');
+        var content = document.getElementById('content');
+        var keyhints = document.getElementById('keyhints');
+
+        var structure = [];
+        var currentWsIdx = 0;
+        var currentBpKey = '';
+        var bpData = null; // { requirements, automations, readme, worktree, bpPath }
+        var mode = 'navigate';
+
+        function cycleStatus(s) { var o=['pending','pass','fail','retest','proposed']; return o[(o.indexOf(s)+1)%o.length]; }
+
+        function setMode(m) {
+            mode = m;
+            if (m === 'navigate') {
+                keyhints.innerHTML = '<span><kbd>\\u2191</kbd><kbd>\\u2193</kbd> Siblings</span><span><kbd>\\u2192</kbd> Child</span><span><kbd>\\u2190</kbd> Parent</span><span><kbd>Enter</kbd> Edit</span><span><kbd>Space</kbd> Cycle status</span><span><kbd>N</kbd> New</span><span><kbd>C</kbd> Child</span><span><kbd>Del</kbd> Remove</span>';
+            } else if (m === 'editing') {
+                keyhints.innerHTML = '<span><kbd>Enter</kbd> Save</span><span><kbd>Shift+Enter</kbd> Newline</span><span><kbd>Esc</kbd> Cancel</span>';
+            } else if (m === 'adding') {
+                keyhints.innerHTML = '<span><kbd>Enter</kbd> Add</span><span><kbd>Shift+Enter</kbd> Newline</span><span><kbd>Esc</kbd> Cancel</span>';
+            }
+        }
+
+        function renderTabs() {
+            tabBar.innerHTML = '';
+            structure.forEach(function(ws, idx) {
+                var tab = document.createElement('div');
+                tab.className = 'tab' + (idx === currentWsIdx ? ' active' : '');
+                tab.textContent = ws.name;
+                tab.addEventListener('click', function() { currentWsIdx = idx; currentBpKey = ''; bpData = null; renderSubtabs(); renderContent(); });
+                tabBar.appendChild(tab);
+            });
+        }
+
+        function renderSubtabs() {
+            subtabBar.innerHTML = '';
+            var ws = structure[currentWsIdx];
+            if (!ws) return;
+            ws.bps.forEach(function(bp) {
+                var tab = document.createElement('div');
+                tab.className = 'subtab' + (bp.key === currentBpKey ? ' active' : '');
+                tab.textContent = bp.label;
+                tab.addEventListener('click', function() {
+                    currentBpKey = bp.key;
+                    bpData = null;
+                    vscodeApi.postMessage({ type: 'loadBP', key: bp.key });
+                    renderSubtabs();
+                    renderContent();
+                });
+                subtabBar.appendChild(tab);
+            });
+            if (!currentBpKey && ws.bps.length > 0) {
+                currentBpKey = ws.bps[0].key;
+                vscodeApi.postMessage({ type: 'loadBP', key: currentBpKey });
+                renderSubtabs();
+            }
+        }
+
+        function mkEl(tag, cls, text) { var e = document.createElement(tag); if (cls) e.className = cls; if (text) e.textContent = text; return e; }
+
+        function renderContent() {
+            content.innerHTML = '';
+            setMode('navigate');
+            if (!currentBpKey) {
+                content.innerHTML = '<div class="placeholder">Select a business process tab above.</div>';
+                return;
+            }
+            if (!bpData) {
+                content.innerHTML = '<div class="placeholder">Loading...</div>';
+                return;
+            }
+
+            // Action cards (Coding Agent + Terminal) — only for worktrees
+            if (bpData.worktree) {
+                var actionsSection = mkEl('div', 'section');
+                actionsSection.appendChild(mkEl('div', 'section-title', 'Actions'));
+                var actionsRow = mkEl('div', 'action-cards');
+
+                var agentCard = mkEl('div', 'action-card');
+                agentCard.innerHTML = '<div class="card-icon">\\u{1F916}</div><div class="card-label">Coding Agent</div><div class="card-desc">Launch Claude in this BP</div>';
+                agentCard.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'openCodingAgent', worktree: bpData.worktree, bpPath: bpData.bpPath });
+                });
+                actionsRow.appendChild(agentCard);
+
+                var termCard = mkEl('div', 'action-card');
+                termCard.innerHTML = '<div class="card-icon">\\u{1F4BB}</div><div class="card-label">Terminal</div><div class="card-desc">Plain shell in this BP</div>';
+                termCard.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'openTerminal', worktree: bpData.worktree, bpPath: bpData.bpPath });
+                });
+                actionsRow.appendChild(termCard);
+
+                actionsSection.appendChild(actionsRow);
+                content.appendChild(actionsSection);
+            }
+
+            // Automations
+            if (bpData.automations && bpData.automations.length > 0) {
+                var autoSection = mkEl('div', 'section');
+                autoSection.appendChild(mkEl('div', 'section-title', 'Automations'));
+                var autoCards = mkEl('div', 'auto-cards');
+
+                bpData.automations.forEach(function(auto) {
+                    var card = mkEl('div', 'auto-card');
+                    if (auto.url) {
+                        card.addEventListener('click', function(e) {
+                            if (e.target.tagName === 'BUTTON') return;
+                            vscodeApi.postMessage({ type: 'openUrl', url: auto.url });
+                        });
+                    }
+
+                    var header = mkEl('div', 'auto-card-header');
+                    header.appendChild(mkEl('span', 'auto-card-name', auto.name));
+                    var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
+                    header.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
+                    card.appendChild(header);
+
+                    if (auto.url) {
+                        var urlLine = mkEl('div', '', '');
+                        urlLine.style.cssText = 'font-size:11px; color:var(--vscode-descriptionForeground); margin-bottom:4px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;';
+                        urlLine.textContent = auto.url;
+                        card.appendChild(urlLine);
+                    }
+
+                    if (auto.deploymentId) {
+                        var actions = mkEl('div', 'auto-card-actions');
+                        var logsBtn = mkEl('button', 'btn', 'Logs');
+                        logsBtn.addEventListener('click', function(e) {
+                            e.stopPropagation();
+                            vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
+                        });
+                        actions.appendChild(logsBtn);
+
+                        var restartBtn = mkEl('button', 'btn', 'Restart');
+                        restartBtn.addEventListener('click', function(e) {
+                            e.stopPropagation();
+                            vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
+                        });
+                        actions.appendChild(restartBtn);
+                        card.appendChild(actions);
+                    }
+
+                    autoCards.appendChild(card);
+                });
+                autoSection.appendChild(autoCards);
+                content.appendChild(autoSection);
+            }
+
+            // README
+            if (bpData.readme) {
+                var readmeSection = mkEl('div', 'section');
+                readmeSection.appendChild(mkEl('div', 'section-title', 'README'));
+                var readmeDiv = mkEl('div', 'readme');
+                readmeDiv.textContent = bpData.readme;
+                readmeSection.appendChild(readmeDiv);
+                content.appendChild(readmeSection);
+            }
+
+            // Requirements
+            var reqSection = mkEl('div', 'section');
+            reqSection.appendChild(mkEl('div', 'section-title', 'Requirements'));
+            if (bpData.requirements.length === 0) {
+                reqSection.appendChild(mkEl('div', 'placeholder', 'No requirements yet. Press N to add one.'));
+            } else {
+                var tree = buildTree(bpData.requirements);
+                var list = mkEl('div', '');
+                renderTree(tree, list);
+                reqSection.appendChild(list);
+            }
+            var addRoot = mkEl('button', 'add-root-btn', '+ Add Requirement');
+            addRoot.addEventListener('click', function() { showAddInput('', addRoot); });
+            reqSection.appendChild(addRoot);
+            content.appendChild(reqSection);
+        }
+
+        // ---- Requirements tree (same logic as before) ----
+
+        function buildTree(reqs) {
+            var map = {}; var roots = [];
+            reqs.forEach(function(r) { map[r.id] = { req: r, children: [] }; });
+            reqs.forEach(function(r) {
+                if (r.parent && map[r.parent]) { map[r.parent].children.push(map[r.id]); }
+                else { roots.push(map[r.id]); }
+            });
+            return roots;
+        }
+
+        function getSiblings(card) {
+            var parentId = card.getAttribute('data-parent') || '';
+            return Array.from(content.querySelectorAll('.req-card')).filter(function(c) {
+                return (c.getAttribute('data-parent') || '') === parentId;
+            });
+        }
+        function getChildren(card) {
+            var id = card.getAttribute('data-req-id');
+            return Array.from(content.querySelectorAll('.req-card')).filter(function(c) {
+                return c.getAttribute('data-parent') === id;
+            });
+        }
+        function getParentCard(card) {
+            var parentId = card.getAttribute('data-parent');
+            if (!parentId) return null;
+            return content.querySelector('.req-card[data-req-id="' + parentId + '"]');
+        }
+        function focusCard(card) { if (card) { card.focus(); setMode('navigate'); } }
+
+        function showAddInput(parentId, afterElement) {
+            var existing = document.querySelector('.add-input-row');
+            if (existing) existing.remove();
+            setMode('adding');
+            var row = mkEl('div', '');
+            row.className = 'add-input-row';
+            row.style.cssText = 'display:flex; gap:6px; margin:6px 0; align-items:flex-start;';
+            var ta = document.createElement('textarea');
+            ta.style.cssText = 'flex:1; padding:6px 8px; min-height:36px; background:var(--vscode-input-background); color:var(--vscode-input-foreground); border:1px solid var(--vscode-focusBorder); border-radius:4px; font-size:12px; font-family:inherit; resize:vertical;';
+            ta.placeholder = parentId ? 'Child requirement...' : 'New requirement...';
+            function submit() {
+                var desc = ta.value.trim();
+                if (desc) { vscodeApi.postMessage({ type: 'addRequirement', key: currentBpKey, requirement: { description: desc, status: 'pending', parent: parentId } }); }
+                row.remove(); setMode('navigate');
+            }
+            ta.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submit(); }
+                else if (e.key === 'Escape') { row.remove(); setMode('navigate'); }
+            });
+            row.appendChild(ta);
+            var insertTarget = afterElement;
+            if (afterElement.classList && afterElement.classList.contains('req-card')) {
+                var wrapper = afterElement.closest('.req-node');
+                if (wrapper) insertTarget = wrapper;
+            }
+            insertTarget.insertAdjacentElement('afterend', row);
+            ta.focus();
+        }
+
+        function startEdit(card, node) {
+            setMode('editing');
+            var desc = card.querySelector('.req-desc');
+            var editTa = document.createElement('textarea');
+            editTa.value = node.req.description || '';
+            desc.textContent = '';
+            desc.appendChild(editTa);
+            editTa.focus();
+            function commit() {
+                if (editTa.value !== (node.req.description || '')) {
+                    vscodeApi.postMessage({ type: 'updateRequirement', key: currentBpKey,
+                        requirement: Object.assign({}, node.req, { description: editTa.value }) });
+                } else { desc.textContent = node.req.description || ''; }
+                setMode('navigate'); card.focus();
+            }
+            editTa.addEventListener('blur', commit);
+            editTa.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); editTa.blur(); }
+                else if (e.key === 'Escape') { desc.textContent = node.req.description || ''; setMode('navigate'); card.focus(); }
+            });
+        }
+
+        function renderTree(nodes, container) {
+            nodes.forEach(function(node) {
+                var wrapper = mkEl('div', 'req-node');
+                var card = mkEl('div', 'req-card');
+                card.setAttribute('tabindex', '0');
+                card.setAttribute('data-req-id', node.req.id);
+                card.setAttribute('data-parent', node.req.parent || '');
+                card._node = node;
+                var header = mkEl('div', 'req-card-header');
+                header.appendChild(mkEl('span', 'req-id', node.req.id));
+                var badge = mkEl('span', 'status-badge ' + (node.req.status || 'pending'), node.req.status || 'pending');
+                badge.title = 'Click to cycle status';
+                badge.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'updateRequirement', key: currentBpKey,
+                        requirement: Object.assign({}, node.req, { status: cycleStatus(node.req.status || 'pending') }) });
+                });
+                header.appendChild(badge);
+                var actions = mkEl('div', 'req-actions');
+                var delBtn = mkEl('button', 'btn-ghost btn-sm', 'Delete');
+                delBtn.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'deleteRequirement', key: currentBpKey, requirementId: node.req.id });
+                });
+                actions.appendChild(delBtn);
+                header.appendChild(actions);
+                card.appendChild(header);
+                var desc = mkEl('div', 'req-desc');
+                desc.textContent = node.req.description || '';
+                desc.addEventListener('click', function() { startEdit(card, node); });
+                card.appendChild(desc);
+                var addChildBtn = mkEl('button', 'add-child-btn', '+');
+                (function(id, btn) {
+                    btn.addEventListener('click', function(e) { e.stopPropagation(); showAddInput(id, btn); });
+                })(node.req.id, addChildBtn);
+                card.appendChild(addChildBtn);
+                wrapper.appendChild(card);
+                if (node.children.length > 0) {
+                    var childContainer = mkEl('div', 'req-children');
+                    renderTree(node.children, childContainer);
+                    wrapper.appendChild(childContainer);
+                }
+                container.appendChild(wrapper);
+            });
+        }
+
+        // Keyboard navigation
+        document.addEventListener('keydown', function(e) {
+            if (mode !== 'navigate') return;
+            var card = document.activeElement;
+            var isCard = card && card.classList && card.classList.contains('req-card');
+            if (!isCard && currentBpKey) {
+                if (e.key === 'ArrowDown' || e.key === 'ArrowRight') { e.preventDefault(); var first = content.querySelector('.req-card'); if (first) focusCard(first); return; }
+                if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') { e.preventDefault(); var all = content.querySelectorAll('.req-card'); if (all.length > 0) focusCard(all[all.length - 1]); return; }
+                if (e.key === 'n' || e.key === 'N') { e.preventDefault(); var addRoot = content.querySelector('.add-root-btn'); if (addRoot) showAddInput('', addRoot); }
+                return;
+            }
+            if (!isCard) return;
+            var node = card._node;
+            if (!node) return;
+            if (e.key === 'ArrowDown') { e.preventDefault(); var sibs = getSiblings(card); var idx = sibs.indexOf(card); if (idx < sibs.length - 1) focusCard(sibs[idx + 1]); }
+            else if (e.key === 'ArrowUp') { e.preventDefault(); var sibs = getSiblings(card); var idx = sibs.indexOf(card); if (idx > 0) focusCard(sibs[idx - 1]); }
+            else if (e.key === 'ArrowRight') { e.preventDefault(); var kids = getChildren(card); if (kids.length > 0) focusCard(kids[0]); }
+            else if (e.key === 'ArrowLeft') { e.preventDefault(); var parent = getParentCard(card); if (parent) focusCard(parent); }
+            else if (e.key === 'Enter') { e.preventDefault(); startEdit(card, node); }
+            else if (e.key === ' ') { e.preventDefault(); vscodeApi.postMessage({ type: 'updateRequirement', key: currentBpKey, requirement: Object.assign({}, node.req, { status: cycleStatus(node.req.status || 'pending') }) }); }
+            else if (e.key === 'n' || e.key === 'N') { e.preventDefault(); showAddInput(node.req.parent || '', card); }
+            else if (e.key === 'c' || e.key === 'C') { e.preventDefault(); showAddInput(node.req.id, card.querySelector('.add-child-btn') || card); }
+            else if (e.key === 'Delete' || e.key === 'Backspace') { e.preventDefault(); vscodeApi.postMessage({ type: 'deleteRequirement', key: currentBpKey, requirementId: node.req.id }); }
+        });
+
+        window.addEventListener('message', function(event) {
+            var msg = event.data;
+            if (!msg || !msg.type) return;
+            switch (msg.type) {
+                case 'structure':
+                    structure = msg.workspaces || [];
+                    renderTabs();
+                    renderSubtabs();
+                    renderContent();
+                    break;
+                case 'bpContent':
+                    if (msg.key === currentBpKey) {
+                        bpData = msg;
+                        renderContent();
+                    }
+                    break;
+            }
+        });
+
+        vscodeApi.postMessage({ type: 'ready' });
+    </script>
+</body>
+</html>
+        `;
+    }
+}

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -516,10 +516,12 @@ export class DashboardPanel {
         scriptLines.push(`exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
         fs.writeFileSync(scriptPath, scriptLines.join('\n') + '\n');
 
-        const terminal = vscode.window.createTerminal(name);
+        const terminal = vscode.window.createTerminal({
+            name,
+            shellPath: '/usr/bin/env',
+            shellArgs: ['bash', scriptPath],
+        });
         terminal.show(true);
-        // source + exec: the exec replaces bash with ssh, so when ssh exits the terminal closes
-        terminal.sendText(`source ${scriptPath}`);
 
         // Track active session
         const termName = terminal.name;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -1092,19 +1092,19 @@ export class DashboardPanel {
                         // Action buttons at bottom
                         var actions = mkEl('div', 'auto-card-actions');
                         if (auto.deploymentId) {
-                            var logsBtn = mkEl('button', 'btn', '\u{1F4DC} Logs');
+                            var logsBtn = mkEl('button', 'btn', '\u{2261} Logs');
                             logsBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(logsBtn);
 
-                            var restartBtn = mkEl('button', 'btn', '\u{1F504} Restart');
+                            var restartBtn = mkEl('button', 'btn', '\u{21BB} Restart');
                             restartBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(restartBtn);
                         } else if (bpData.worktree) {
-                            var startBtn = mkEl('button', 'btn btn-primary', '\u{25B6}\u{FE0F} Start Live Dev');
+                            var startBtn = mkEl('button', 'btn btn-primary', '\u{25B6} Start Live Dev');
                             startBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'startLiveDev', relativePath: auto.relativePath, worktree: bpData.worktree, name: auto.name });
                             });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -520,7 +520,8 @@ export class DashboardPanel {
 
         const terminal = vscode.window.createTerminal({
             name,
-            shellPath: scriptPath,
+            shellPath: '/bin/bash',
+            shellArgs: [scriptPath],
         });
         terminal.show(true);
 

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -3,7 +3,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as cp from 'child_process';
 import * as toml from '@iarna/toml';
+import axios from 'axios';
 import { getUserEmail } from '../services/user_info';
+import { getDeployDetails } from '../deploy_details';
 
 const REQUIREMENTS_FILENAME = 'testable-requirements.toml';
 const WORKSPACE_DIR = '/workspace/workspace';
@@ -168,7 +170,7 @@ export class DashboardPanel {
                         if (auto) {
                             const name = auto.name || auto.deployment_id;
                             try {
-                                const { restartAutomation } = await import('../lib');
+                                const { restartAutomation } = require('../lib');
                                 const url = `${activeInstance.url}/automations/${name}/restart`;
                                 await restartAutomation(url, activeInstance.secret);
                                 vscode.window.showInformationMessage(`Restarted ${name}`);
@@ -460,11 +462,9 @@ export class DashboardPanel {
             title: 'Starting coding agent container...',
             cancellable: false,
         }, async (progress) => {
-            const { getDeployDetails } = await import('../deploy_details');
             const details = await getDeployDetails(this.context);
             if (!details) { return false; }
             try {
-                const axios = (await import('axios')).default;
                 await axios.post(
                     `${details.deployUrl}/worktrees/coding-agent/ensure`,
                     {},
@@ -569,10 +569,8 @@ export class DashboardPanel {
 
         try {
             // Try GitOps API first
-            const { getDeployDetails } = await import('../deploy_details');
             const details = await getDeployDetails(this.context);
             if (details) {
-                const axios = (await import('axios')).default;
                 await axios.post(
                     `${details.deployUrl}/worktrees/create`,
                     { branch_name: name },
@@ -642,13 +640,10 @@ export class DashboardPanel {
         );
         if (confirm !== 'Merge') { return; }
 
-        const { getDeployDetails } = await import('../deploy_details');
         const details = await getDeployDetails(this.context);
         if (!details) { return; }
 
         try {
-            const axios = (await import('axios')).default;
-
             // First commit any uncommitted changes
             try {
                 await axios.post(

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -462,9 +462,10 @@ export class DashboardPanel {
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const logged = anon ? 'false' : 'true';
             const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
+            const autoCmdB64 = Buffer.from(autoCmd).toString('base64');
             const terminal = vscode.window.createTerminal(`Claude: ${worktree}/${bpPath}`);
             terminal.show(true);
-            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="$(echo ${autoCmdB64} | base64 -d)" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
@@ -516,9 +517,10 @@ export class DashboardPanel {
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const logged = anon ? 'false' : 'true';
             const autoCmd = `cd ${cdPath} && exec bash`;
+            const autoCmdB64 = Buffer.from(autoCmd).toString('base64');
             const terminal = vscode.window.createTerminal(`Terminal: ${worktree}/${bpPath}`);
             terminal.show(true);
-            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="$(echo ${autoCmdB64} | base64 -d)" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
@@ -731,9 +733,10 @@ export class DashboardPanel {
         ].join('\\n');
 
         const mergeAutoCmd = `cd ${wtPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
+        const mergeB64 = Buffer.from(mergeAutoCmd).toString('base64');
         const terminal = vscode.window.createTerminal(`Merge: ${worktree}`);
         terminal.show(true);
-        terminal.sendText(`exec SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="true" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${mergeAutoCmd}" ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+        terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="true" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="$(echo ${mergeB64} | base64 -d)" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
     }
 
     private sendActiveSessions(): void {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -500,30 +500,26 @@ export class DashboardPanel {
         const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
         const logged = anon ? 'false' : 'true';
 
-        // Write a temp script to avoid all quoting/timing issues with sendText
+        // Write a temp script to avoid quoting issues
         const tmpDir = '/tmp/bitswan-terminals';
         if (!fs.existsSync(tmpDir)) { fs.mkdirSync(tmpDir, { recursive: true }); }
         const scriptPath = path.join(tmpDir, `agent-${Date.now()}.sh`);
-        const lines = [
-            '#!/bin/bash',
+        const scriptLines = [
             `export SSH_USER_EMAIL="${userEmail}"`,
             `export SSH_LOGGED="${logged}"`,
             `export SSH_WORKTREE="${worktree}"`,
         ];
         if (autoCmd) {
             const b64 = Buffer.from(autoCmd).toString('base64');
-            lines.push(`export SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`);
+            scriptLines.push(`export SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`);
         }
-        lines.push(`exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
-        fs.writeFileSync(scriptPath, lines.join('\n') + '\n');
-        fs.chmodSync(scriptPath, 0o755);
+        scriptLines.push(`ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+        fs.writeFileSync(scriptPath, scriptLines.join('\n') + '\n');
 
-        const terminal = vscode.window.createTerminal({
-            name,
-            shellPath: '/bin/bash',
-            shellArgs: [scriptPath],
-        });
+        const terminal = vscode.window.createTerminal(name);
         terminal.show(true);
+        // Use source to run the script in the current shell
+        terminal.sendText(`source ${scriptPath}`);
 
         // Track active session
         const termName = terminal.name;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -515,7 +515,8 @@ export class DashboardPanel {
             lines.push(`export SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`);
         }
         lines.push(`exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
-        fs.writeFileSync(scriptPath, lines.join('\n') + '\n', { mode: 0o755 });
+        fs.writeFileSync(scriptPath, lines.join('\n') + '\n');
+        fs.chmodSync(scriptPath, 0o755);
 
         const terminal = vscode.window.createTerminal({
             name,

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -461,13 +461,10 @@ export class DashboardPanel {
 
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const logged = anon ? 'false' : 'true';
-            const autoCmd = `cd '${cdPath}' && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
-            const terminal = vscode.window.createTerminal({
-                name: `Claude: ${worktree}/${bpPath}`,
-                shellPath: '/bin/bash',
-                shellArgs: ['-c', `exec SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' SSH_AUTO_CMD='${autoCmd.replace(/'/g, "'\\''")}' ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`],
-            });
+            const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
+            const terminal = vscode.window.createTerminal(`Claude: ${worktree}/${bpPath}`);
             terminal.show(true);
+            terminal.sendText(`exec SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
@@ -518,13 +515,10 @@ export class DashboardPanel {
 
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const logged = anon ? 'false' : 'true';
-            const autoCmd = `cd '${cdPath}' && exec bash`;
-            const terminal = vscode.window.createTerminal({
-                name: `Terminal: ${worktree}/${bpPath}`,
-                shellPath: '/bin/bash',
-                shellArgs: ['-c', `exec SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' SSH_AUTO_CMD='${autoCmd.replace(/'/g, "'\\''")}' ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`],
-            });
+            const autoCmd = `cd ${cdPath} && exec bash`;
+            const terminal = vscode.window.createTerminal(`Terminal: ${worktree}/${bpPath}`);
             terminal.show(true);
+            terminal.sendText(`exec SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
@@ -736,13 +730,10 @@ export class DashboardPanel {
             `4. Once the merge is complete, tell the user it's done`,
         ].join('\\n');
 
-        const mergeAutoCmd = `cd '${wtPath}' && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
-        const terminal = vscode.window.createTerminal({
-            name: `Merge: ${worktree}`,
-            shellPath: '/bin/bash',
-            shellArgs: ['-c', `exec SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='true' SSH_WORKTREE='${worktree}' SSH_AUTO_CMD='${mergeAutoCmd.replace(/'/g, "'\\''")}' ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`],
-        });
+        const mergeAutoCmd = `cd ${wtPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
+        const terminal = vscode.window.createTerminal(`Merge: ${worktree}`);
         terminal.show(true);
+        terminal.sendText(`exec SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="true" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${mergeAutoCmd}" ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
     }
 
     private sendActiveSessions(): void {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -259,6 +259,69 @@ export class DashboardPanel {
             case 'mergeWorktree':
                 await this.mergeWorktree(msg.worktree);
                 break;
+            case 'openFile': {
+                const dirPath = this.bpMap.get(msg.key);
+                if (dirPath && msg.relPath) {
+                    const filePath = path.join(dirPath, msg.relPath);
+                    if (fs.existsSync(filePath)) {
+                        const doc = await vscode.workspace.openTextDocument(filePath);
+                        await vscode.window.showTextDocument(doc);
+                    }
+                }
+                break;
+            }
+            case 'createFile': {
+                const dir = this.bpMap.get(msg.key);
+                if (dir && msg.name) {
+                    const target = path.join(dir, msg.parentPath || '', msg.name);
+                    fs.mkdirSync(path.dirname(target), { recursive: true });
+                    fs.writeFileSync(target, '', 'utf-8');
+                    this._reloadCurrentKey();
+                }
+                break;
+            }
+            case 'createFolder': {
+                const dir2 = this.bpMap.get(msg.key);
+                if (dir2 && msg.name) {
+                    fs.mkdirSync(path.join(dir2, msg.parentPath || '', msg.name), { recursive: true });
+                    this._reloadCurrentKey();
+                }
+                break;
+            }
+            case 'deleteFile': {
+                const dir3 = this.bpMap.get(msg.key);
+                if (dir3 && msg.relPath) {
+                    const target = path.join(dir3, msg.relPath);
+                    const confirm = await vscode.window.showWarningMessage(
+                        `Delete "${msg.relPath}"?`, { modal: true }, 'Delete'
+                    );
+                    if (confirm === 'Delete') {
+                        fs.rmSync(target, { recursive: true, force: true });
+                        this._reloadCurrentKey();
+                    }
+                }
+                break;
+            }
+            case 'renameFile': {
+                const dir4 = this.bpMap.get(msg.key);
+                if (dir4 && msg.relPath && msg.newName) {
+                    const oldPath = path.join(dir4, msg.relPath);
+                    const newPath = path.join(path.dirname(oldPath), msg.newName);
+                    fs.renameSync(oldPath, newPath);
+                    this._reloadCurrentKey();
+                }
+                break;
+            }
+            case 'uploadFile': {
+                const dir5 = this.bpMap.get(msg.key);
+                if (dir5 && msg.name && msg.data) {
+                    const target = path.join(dir5, msg.parentPath || '', msg.name);
+                    fs.mkdirSync(path.dirname(target), { recursive: true });
+                    fs.writeFileSync(target, Buffer.from(msg.data, 'base64'));
+                    this._reloadCurrentKey();
+                }
+                break;
+            }
             case 'focusTerminal': {
                 const t = vscode.window.terminals.find(t => t.name === msg.terminalName);
                 if (t) { t.show(true); }
@@ -388,10 +451,35 @@ export class DashboardPanel {
             bpPath = key.substring('workspace:'.length);
         }
 
+        // Files
+        const files = this._scanFiles(dirPath, dirPath);
+
         // Agent sessions for this worktree
         const sessions = worktree ? this._scanSessions(worktree) : [];
 
-        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, sessions });
+        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, files, sessions });
+    }
+
+    private _scanFiles(dir: string, rootDir: string): { name: string; relPath: string; isDirectory: boolean; children?: any[] }[] {
+        const results: { name: string; relPath: string; isDirectory: boolean; children?: any[] }[] = [];
+        try {
+            const entries = fs.readdirSync(dir, { withFileTypes: true });
+            for (const entry of entries) {
+                if (entry.name.startsWith('.') || entry.name === 'node_modules') { continue; }
+                const fullPath = path.join(dir, entry.name);
+                const relPath = path.relative(rootDir, fullPath);
+                if (entry.isDirectory()) {
+                    results.push({ name: entry.name, relPath, isDirectory: true, children: this._scanFiles(fullPath, rootDir) });
+                } else {
+                    results.push({ name: entry.name, relPath, isDirectory: false });
+                }
+            }
+        } catch { /* */ }
+        results.sort((a, b) => {
+            if (a.isDirectory !== b.isDirectory) { return a.isDirectory ? -1 : 1; }
+            return a.name.localeCompare(b.name);
+        });
+        return results;
     }
 
     private _scanSessions(worktree: string): { timestamp: string; userEmail: string; worktree: string; castFile: string; logged: boolean }[] {
@@ -863,6 +951,18 @@ export class DashboardPanel {
         .auto-card-state.not-deployed { background:var(--status-proposed); color:#fff; }
         .auto-card-actions { display:flex; gap:6px; border-top:1px solid var(--border); padding:10px 16px; }
 
+        /* File tree */
+        .file-tree { font-size:12px; }
+        .file-item { display:flex; align-items:center; gap:6px; padding:3px 4px; border-radius:4px; cursor:pointer; }
+        .file-item:hover { background:var(--vscode-list-hoverBackground, rgba(128,128,128,0.08)); }
+        .file-item-icon { width:16px; text-align:center; flex-shrink:0; }
+        .file-item-name { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+        .file-item-actions { display:none; gap:4px; }
+        .file-item:hover .file-item-actions { display:flex; }
+        .file-item-btn { background:none; border:none; color:var(--vscode-descriptionForeground); cursor:pointer; font-size:11px; padding:0 2px; }
+        .file-item-btn:hover { color:var(--vscode-foreground); }
+        .file-children { margin-left:16px; }
+
         /* Buttons */
         .btn { padding:4px 10px; border:1px solid var(--vscode-button-border, transparent); border-radius:4px; background:var(--vscode-button-secondaryBackground, rgba(128,128,128,0.2)); color:var(--vscode-button-secondaryForeground, var(--vscode-foreground)); cursor:pointer; font-size:11px; }
         .btn:hover { opacity:0.85; }
@@ -1159,6 +1259,69 @@ export class DashboardPanel {
                 content.appendChild(readmeSection);
             }
 
+            // Requirements
+            var reqSection = mkEl('div', 'section');
+            reqSection.appendChild(mkEl('div', 'section-title', 'Requirements'));
+            if (bpData.requirements.length === 0) {
+                reqSection.appendChild(mkEl('div', 'placeholder', 'No requirements yet. Press N to add one.'));
+            } else {
+                var tree = buildTree(bpData.requirements);
+                var list = mkEl('div', '');
+                renderTree(tree, list);
+                reqSection.appendChild(list);
+            }
+            var addRoot = mkEl('button', 'add-root-btn', '+ Add Requirement');
+            addRoot.addEventListener('click', function() { showAddInput('', addRoot); });
+            reqSection.appendChild(addRoot);
+            content.appendChild(reqSection);
+
+            // Files
+            if (bpData.files) {
+                var filesSection = mkEl('div', 'section');
+                var filesHeader = mkEl('div', '');
+                filesHeader.style.cssText = 'display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;';
+                filesHeader.appendChild(mkEl('div', 'section-title', 'Files'));
+                var fileActions = mkEl('div', '');
+                fileActions.style.cssText = 'display:flex; gap:6px;';
+                var newFileBtn = mkEl('button', 'btn btn-sm', '+ File');
+                newFileBtn.addEventListener('click', function() {
+                    var name = prompt('File name:');
+                    if (name) { vscodeApi.postMessage({ type: 'createFile', key: currentBpKey, name: name, parentPath: '' }); }
+                });
+                var newFolderBtn = mkEl('button', 'btn btn-sm', '+ Folder');
+                newFolderBtn.addEventListener('click', function() {
+                    var name = prompt('Folder name:');
+                    if (name) { vscodeApi.postMessage({ type: 'createFolder', key: currentBpKey, name: name, parentPath: '' }); }
+                });
+                var uploadBtn = mkEl('button', 'btn btn-sm', 'Upload');
+                uploadBtn.addEventListener('click', function() {
+                    var input = document.createElement('input');
+                    input.type = 'file';
+                    input.addEventListener('change', function() {
+                        if (input.files && input.files[0]) {
+                            var file = input.files[0];
+                            var reader = new FileReader();
+                            reader.onload = function() {
+                                var base64 = reader.result.toString().split(',')[1];
+                                vscodeApi.postMessage({ type: 'uploadFile', key: currentBpKey, name: file.name, data: base64, parentPath: '' });
+                            };
+                            reader.readAsDataURL(file);
+                        }
+                    });
+                    input.click();
+                });
+                fileActions.appendChild(newFileBtn);
+                fileActions.appendChild(newFolderBtn);
+                fileActions.appendChild(uploadBtn);
+                filesHeader.appendChild(fileActions);
+                filesSection.appendChild(filesHeader);
+
+                var fileTree = mkEl('div', 'file-tree');
+                renderFileTree(bpData.files, fileTree, '');
+                filesSection.appendChild(fileTree);
+                content.appendChild(filesSection);
+            }
+
             // Agent Sessions
             if (bpData.worktree) {
                 var sessSection = mkEl('div', 'section');
@@ -1166,7 +1329,6 @@ export class DashboardPanel {
                 sessHeader.style.cssText = 'display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;';
                 sessHeader.appendChild(mkEl('div', 'section-title', 'Agent Sessions'));
 
-                // Recording toggle
                 var toggleLabel = mkEl('label', '');
                 toggleLabel.style.cssText = 'display:flex; align-items:center; gap:6px; font-size:11px; color:var(--vscode-descriptionForeground); cursor:pointer;';
                 var toggleCb = document.createElement('input');
@@ -1180,13 +1342,11 @@ export class DashboardPanel {
                 sessHeader.appendChild(toggleLabel);
                 sessSection.appendChild(sessHeader);
 
-                // Active sessions
                 var activeDiv = mkEl('div', '');
                 activeDiv.id = 'activeSessions';
                 renderActiveSessions(activeDiv);
                 sessSection.appendChild(activeDiv);
 
-                // Playback area (hidden by default)
                 var playbackArea = mkEl('div', '');
                 playbackArea.id = 'playbackArea';
                 playbackArea.style.cssText = 'display:none; margin-bottom:12px; border:1px solid var(--border); border-radius:8px; overflow:hidden; background:#000;';
@@ -1210,18 +1370,13 @@ export class DashboardPanel {
                         tbody.appendChild(tr);
                     });
                     sessTable.appendChild(tbody);
-
-                    // Wire up play buttons
                     sessTable.addEventListener('click', function(e) {
                         var btn = e.target;
                         if (btn && btn.classList && btn.classList.contains('play-btn')) {
                             var castFile = btn.getAttribute('data-cast');
-                            if (castFile) {
-                                vscodeApi.postMessage({ type: 'playSession', castFile: castFile });
-                            }
+                            if (castFile) { vscodeApi.postMessage({ type: 'playSession', castFile: castFile }); }
                         }
                     });
-
                     sessSection.appendChild(sessTable);
                 } else {
                     sessSection.appendChild(mkEl('div', 'placeholder', 'No sessions yet.'));
@@ -1229,25 +1384,59 @@ export class DashboardPanel {
 
                 content.appendChild(sessSection);
             }
-
-            // Requirements
-            var reqSection = mkEl('div', 'section');
-            reqSection.appendChild(mkEl('div', 'section-title', 'Requirements'));
-            if (bpData.requirements.length === 0) {
-                reqSection.appendChild(mkEl('div', 'placeholder', 'No requirements yet. Press N to add one.'));
-            } else {
-                var tree = buildTree(bpData.requirements);
-                var list = mkEl('div', '');
-                renderTree(tree, list);
-                reqSection.appendChild(list);
-            }
-            var addRoot = mkEl('button', 'add-root-btn', '+ Add Requirement');
-            addRoot.addEventListener('click', function() { showAddInput('', addRoot); });
-            reqSection.appendChild(addRoot);
-            content.appendChild(reqSection);
         }
 
         // ---- Requirements tree (same logic as before) ----
+
+        function renderFileTree(files, container, parentPath) {
+            files.forEach(function(f) {
+                var item = mkEl('div', 'file-item');
+                var icon = mkEl('span', 'file-item-icon', f.isDirectory ? '\\u{1F4C1}' : '\\u{1F4C4}');
+                item.appendChild(icon);
+                var nameSpan = mkEl('span', 'file-item-name', f.name);
+                item.appendChild(nameSpan);
+
+                // Inline action buttons
+                var actions = mkEl('div', 'file-item-actions');
+                var renameBtn = mkEl('button', 'file-item-btn', '\\u{270F}');
+                renameBtn.title = 'Rename';
+                renameBtn.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    var newName = prompt('New name:', f.name);
+                    if (newName && newName !== f.name) {
+                        vscodeApi.postMessage({ type: 'renameFile', key: currentBpKey, relPath: f.relPath, newName: newName });
+                    }
+                });
+                actions.appendChild(renameBtn);
+                var deleteBtn = mkEl('button', 'file-item-btn', '\\u{1F5D1}');
+                deleteBtn.title = 'Delete';
+                deleteBtn.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    vscodeApi.postMessage({ type: 'deleteFile', key: currentBpKey, relPath: f.relPath });
+                });
+                actions.appendChild(deleteBtn);
+                item.appendChild(actions);
+
+                if (f.isDirectory) {
+                    var wrapper = mkEl('div', '');
+                    var childContainer = mkEl('div', 'file-children');
+                    childContainer.style.display = 'none';
+                    item.addEventListener('click', function() {
+                        childContainer.style.display = childContainer.style.display === 'none' ? '' : 'none';
+                        icon.textContent = childContainer.style.display === 'none' ? '\\u{1F4C1}' : '\\u{1F4C2}';
+                    });
+                    wrapper.appendChild(item);
+                    if (f.children) { renderFileTree(f.children, childContainer, f.relPath); }
+                    wrapper.appendChild(childContainer);
+                    container.appendChild(wrapper);
+                } else {
+                    item.addEventListener('click', function() {
+                        vscodeApi.postMessage({ type: 'openFile', key: currentBpKey, relPath: f.relPath });
+                    });
+                    container.appendChild(item);
+                }
+            });
+        }
 
         function buildTree(reqs) {
             var map = {}; var roots = [];

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -464,7 +464,7 @@ export class DashboardPanel {
             const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
             const terminal = vscode.window.createTerminal(`Claude: ${worktree}/${bpPath}`);
             terminal.show(true);
-            terminal.sendText(`exec SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
@@ -518,7 +518,7 @@ export class DashboardPanel {
             const autoCmd = `cd ${cdPath} && exec bash`;
             const terminal = vscode.window.createTerminal(`Terminal: ${worktree}/${bpPath}`);
             terminal.show(true);
-            terminal.sendText(`exec SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+            terminal.sendText(`export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}" SSH_AUTO_CMD="${autoCmd}" && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -460,23 +460,13 @@ export class DashboardPanel {
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
 
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
+            const logged = anon ? 'false' : 'true';
+            const sshCmd = `SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' ssh -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE' agent@${agentHost}`;
             const terminal = vscode.window.createTerminal({
                 name: `Claude: ${worktree}/${bpPath}`,
-                shellPath: '/usr/bin/ssh',
-                shellArgs: [
-                    '-i', '/workspace/.ssh/id_ed25519',
-                    '-o', 'StrictHostKeyChecking=no',
-                    '-o', 'UserKnownHostsFile=/dev/null',
-                    '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
-                    `agent@${agentHost}`,
-                ],
-                env: {
-                    SSH_USER_EMAIL: userEmail,
-                    SSH_LOGGED: anon ? 'false' : 'true',
-                    SSH_WORKTREE: worktree,
-                },
             });
             terminal.show(true);
+            terminal.sendText(sshCmd);
 
             // Track active session
             const termName = terminal.name;
@@ -497,7 +487,7 @@ export class DashboardPanel {
 
             setTimeout(() => {
                 terminal.sendText(`cd "${cdPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions`);
-            }, 2000);
+            }, 3000);
         } else {
             // Main workspace: local terminal
             const cdPath = path.join(WORKSPACE_DIR, bpPath);
@@ -528,23 +518,13 @@ export class DashboardPanel {
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
 
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
+            const logged = anon ? 'false' : 'true';
+            const sshCmd = `SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='${logged}' SSH_WORKTREE='${worktree}' ssh -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE' agent@${agentHost}`;
             const terminal = vscode.window.createTerminal({
                 name: `Terminal: ${worktree}/${bpPath}`,
-                shellPath: '/usr/bin/ssh',
-                shellArgs: [
-                    '-i', '/workspace/.ssh/id_ed25519',
-                    '-o', 'StrictHostKeyChecking=no',
-                    '-o', 'UserKnownHostsFile=/dev/null',
-                    '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
-                    `agent@${agentHost}`,
-                ],
-                env: {
-                    SSH_USER_EMAIL: userEmail,
-                    SSH_LOGGED: anon ? 'false' : 'true',
-                    SSH_WORKTREE: worktree,
-                },
             });
             terminal.show(true);
+            terminal.sendText(sshCmd);
 
             const termName = terminal.name;
             activeSessions.push({ worktree, userEmail, terminalName: termName });
@@ -753,27 +733,16 @@ export class DashboardPanel {
             `4. Once the merge is complete, tell the user it's done`,
         ].join('\\n');
 
+        const sshCmd = `SSH_USER_EMAIL='${userEmail}' SSH_LOGGED='true' SSH_WORKTREE='${worktree}' ssh -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE' agent@${agentHost}`;
         const terminal = vscode.window.createTerminal({
             name: `Merge: ${worktree}`,
-            shellPath: '/usr/bin/ssh',
-            shellArgs: [
-                '-i', '/workspace/.ssh/id_ed25519',
-                '-o', 'StrictHostKeyChecking=no',
-                '-o', 'UserKnownHostsFile=/dev/null',
-                '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
-                `agent@${agentHost}`,
-            ],
-            env: {
-                SSH_USER_EMAIL: userEmail,
-                SSH_LOGGED: 'true',
-                SSH_WORKTREE: worktree,
-            },
         });
         terminal.show(true);
+        terminal.sendText(sshCmd);
 
         setTimeout(() => {
             terminal.sendText(`cd "${wtPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions -p "${claudePrompt}"`);
-        }, 2000);
+        }, 3000);
     }
 
     private sendActiveSessions(): void {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -500,18 +500,28 @@ export class DashboardPanel {
         const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
         const logged = anon ? 'false' : 'true';
 
-        const terminal = vscode.window.createTerminal(name);
-        terminal.show(true);
-
-        // SSH_AUTO_CMD is base64-encoded to avoid shell metachar issues.
-        // Also send the command via sendText as fallback for older containers
-        // that don't support SSH_AUTO_CMD yet.
-        let exportVars = `export SSH_USER_EMAIL="${userEmail}" SSH_LOGGED="${logged}" SSH_WORKTREE="${worktree}"`;
+        // Write a temp script to avoid all quoting/timing issues with sendText
+        const tmpDir = '/tmp/bitswan-terminals';
+        if (!fs.existsSync(tmpDir)) { fs.mkdirSync(tmpDir, { recursive: true }); }
+        const scriptPath = path.join(tmpDir, `agent-${Date.now()}.sh`);
+        const lines = [
+            '#!/bin/bash',
+            `export SSH_USER_EMAIL="${userEmail}"`,
+            `export SSH_LOGGED="${logged}"`,
+            `export SSH_WORKTREE="${worktree}"`,
+        ];
         if (autoCmd) {
             const b64 = Buffer.from(autoCmd).toString('base64');
-            exportVars += ` SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`;
+            lines.push(`export SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`);
         }
-        terminal.sendText(`${exportVars} && ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}; exit`);
+        lines.push(`exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+        fs.writeFileSync(scriptPath, lines.join('\n') + '\n', { mode: 0o755 });
+
+        const terminal = vscode.window.createTerminal({
+            name,
+            shellPath: scriptPath,
+        });
+        terminal.show(true);
 
         // Track active session
         const termName = terminal.name;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -6,6 +6,7 @@ import * as toml from '@iarna/toml';
 import axios from 'axios';
 import { getUserEmail } from '../services/user_info';
 import { getDeployDetails } from '../deploy_details';
+import { AutomationItem } from './automations_view';
 
 const REQUIREMENTS_FILENAME = 'testable-requirements.toml';
 const WORKSPACE_DIR = '/workspace/workspace';
@@ -195,39 +196,41 @@ export class DashboardPanel {
             }
             case 'showLogs':
                 if (msg.deploymentId) {
-                    // Find the automation and trigger log viewer
                     const automations = this.context.globalState.get<any[]>('automations', []);
-                    const automation = automations?.find(a =>
+                    const auto = automations?.find(a =>
                         (a.deployment_id || a.deploymentId) === msg.deploymentId
                     );
-                    if (automation) {
-                        vscode.commands.executeCommand('bitswan.showAutomationLogs', {
-                            name: automation.name || automation.deployment_id,
-                            deploymentId: automation.deployment_id || automation.deploymentId,
-                            automationUrl: automation.automation_url || automation.automationUrl,
-                        });
+                    if (auto) {
+                        const item = new AutomationItem(
+                            auto.name || auto.deployment_id,
+                            auto.state,
+                            auto.status,
+                            auto.deployment_id || auto.deploymentId,
+                            auto.active,
+                            auto.automation_url || auto.automationUrl,
+                            auto.relative_path || auto.relativePath,
+                        );
+                        vscode.commands.executeCommand('bitswan.showAutomationLogs', item);
                     }
                 }
                 break;
             case 'restartAutomation':
                 if (msg.deploymentId) {
-                    const activeInstance = this.context.globalState.get<any>('activeGitOpsInstance');
-                    if (activeInstance) {
-                        const automations = this.context.globalState.get<any[]>('automations', []);
-                        const auto = automations?.find(a =>
-                            (a.deployment_id || a.deploymentId) === msg.deploymentId
+                    const automations2 = this.context.globalState.get<any[]>('automations', []);
+                    const auto2 = automations2?.find(a =>
+                        (a.deployment_id || a.deploymentId) === msg.deploymentId
+                    );
+                    if (auto2) {
+                        const item2 = new AutomationItem(
+                            auto2.name || auto2.deployment_id,
+                            auto2.state,
+                            auto2.status,
+                            auto2.deployment_id || auto2.deploymentId,
+                            auto2.active,
+                            auto2.automation_url || auto2.automationUrl,
+                            auto2.relative_path || auto2.relativePath,
                         );
-                        if (auto) {
-                            const name = auto.name || auto.deployment_id;
-                            try {
-                                const { restartAutomation } = require('../lib');
-                                const url = `${activeInstance.url}/automations/${name}/restart`;
-                                await restartAutomation(url, activeInstance.secret);
-                                vscode.window.showInformationMessage(`Restarted ${name}`);
-                            } catch (err: any) {
-                                vscode.window.showErrorMessage(`Failed to restart: ${err.message}`);
-                            }
-                        }
+                        vscode.commands.executeCommand('bitswan.restartAutomation', item2);
                     }
                 }
                 break;
@@ -833,17 +836,19 @@ export class DashboardPanel {
 
         /* Automation cards */
         .auto-cards { display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:12px; }
-        .auto-card { display:flex; flex-direction:column; padding:16px; border:1px solid var(--border); border-radius:10px; transition: border-color 0.15s, box-shadow 0.15s; }
+        .auto-card { display:flex; flex-direction:column; border:1px solid var(--border); border-radius:10px; transition: border-color 0.15s, box-shadow 0.15s; overflow:hidden; }
         .auto-card:hover { border-color:var(--vscode-focusBorder, #007acc); box-shadow:0 2px 8px rgba(0,0,0,0.1); }
+        .auto-card-top { padding:16px; position:relative; }
+        .auto-card-top.clickable { cursor:pointer; }
+        .auto-card-top.clickable:hover { background:var(--vscode-list-hoverBackground, rgba(128,128,128,0.08)); }
+        .auto-card-link-icon { position:absolute; top:12px; right:12px; font-size:12px; color:var(--vscode-descriptionForeground); }
         .auto-card-icon { font-size:28px; margin-bottom:10px; }
         .auto-card-name { font-weight:600; font-size:14px; margin-bottom:4px; }
         .auto-card-state { display:inline-block; font-size:10px; padding:2px 8px; border-radius:10px; text-transform:uppercase; font-weight:600; letter-spacing:0.3px; margin-bottom:8px; }
         .auto-card-state.running { background:var(--status-pass); color:#fff; }
         .auto-card-state.exited, .auto-card-state.dead { background:var(--status-fail); color:#fff; }
         .auto-card-state.not-deployed { background:var(--status-proposed); color:#fff; }
-        .auto-card-url { font-size:11px; color:var(--vscode-descriptionForeground); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; margin-bottom:8px; }
-        .auto-card-spacer { flex:1; }
-        .auto-card-actions { display:flex; gap:6px; border-top:1px solid var(--border); padding-top:10px; margin-top:4px; }
+        .auto-card-actions { display:flex; gap:6px; border-top:1px solid var(--border); padding:10px 16px; }
 
         /* Buttons */
         .btn { padding:4px 10px; border:1px solid var(--vscode-button-border, transparent); border-radius:4px; background:var(--vscode-button-secondaryBackground, rgba(128,128,128,0.2)); color:var(--vscode-button-secondaryForeground, var(--vscode-foreground)); cursor:pointer; font-size:11px; }
@@ -1070,51 +1075,37 @@ export class DashboardPanel {
                     bpData.automations.forEach(function(auto) {
                         var card = mkEl('div', 'auto-card');
 
-                        // Icon
-                        card.appendChild(mkEl('div', 'auto-card-icon', auto.icon || '\\u{1F4E6}'));
-
-                        // Name
-                        card.appendChild(mkEl('div', 'auto-card-name', auto.name));
-
-                        // State badge
-                        var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
-                        card.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
-
-                        // URL
+                        // Top section (clickable if URL exists)
+                        var top = mkEl('div', 'auto-card-top' + (auto.url ? ' clickable' : ''));
                         if (auto.url) {
-                            var urlEl = mkEl('div', 'auto-card-url');
-                            urlEl.textContent = auto.url;
-                            urlEl.style.cursor = 'pointer';
-                            urlEl.addEventListener('click', function(e) {
-                                e.stopPropagation();
+                            top.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'openUrl', url: auto.url });
                             });
-                            card.appendChild(urlEl);
+                            top.appendChild(mkEl('span', 'auto-card-link-icon', '\\u{1F517}'));
                         }
+                        top.appendChild(mkEl('div', 'auto-card-icon', auto.icon || '\\u{1F4E6}'));
+                        top.appendChild(mkEl('div', 'auto-card-name', auto.name));
+                        var stateClass = (auto.state || 'not-deployed').replace(/\\s+/g, '-').toLowerCase();
+                        top.appendChild(mkEl('span', 'auto-card-state ' + stateClass, auto.state || 'not deployed'));
+                        card.appendChild(top);
 
-                        // Spacer pushes actions to bottom
-                        card.appendChild(mkEl('div', 'auto-card-spacer'));
-
-                        // Action buttons
+                        // Action buttons at bottom
                         var actions = mkEl('div', 'auto-card-actions');
                         if (auto.deploymentId) {
                             var logsBtn = mkEl('button', 'btn', 'Logs');
-                            logsBtn.addEventListener('click', function(e) {
-                                e.stopPropagation();
+                            logsBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(logsBtn);
 
                             var restartBtn = mkEl('button', 'btn', 'Restart');
-                            restartBtn.addEventListener('click', function(e) {
-                                e.stopPropagation();
+                            restartBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(restartBtn);
                         } else if (bpData.worktree) {
                             var startBtn = mkEl('button', 'btn btn-primary', 'Start Live Dev');
-                            startBtn.addEventListener('click', function(e) {
-                                e.stopPropagation();
+                            startBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'startLiveDev', relativePath: auto.relativePath, worktree: bpData.worktree, name: auto.name });
                             });
                             actions.appendChild(startBtn);

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -103,6 +103,11 @@ export class DashboardPanel {
         this.fileWatcher.onDidChange(() => this._reloadCurrentKey());
         this.fileWatcher.onDidCreate(() => this._reloadCurrentKey());
 
+        // Watch for new automations (automation.toml creation)
+        const autoWatcher = vscode.workspace.createFileSystemWatcher('**/automation.toml');
+        autoWatcher.onDidCreate(() => this._reloadCurrentKey());
+        context.subscriptions.push(autoWatcher);
+
         this.panel.onDidDispose(() => {
             this.disposed = true;
             if (this.fileWatcher) { this.fileWatcher.dispose(); }

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -714,72 +714,28 @@ export class DashboardPanel {
         vscode.commands.executeCommand('bitswan.openAutomationTemplates', relPath);
     }
 
-    private async syncWorktree(worktree: string): Promise<void> {
+    /**
+     * Rebase worktree onto main and fast-forward main.
+     * If deleteAfter is true, deletes the worktree on success.
+     * On conflicts, launches Claude to resolve them.
+     */
+    private async rebaseAndMerge(worktree: string, deleteAfter: boolean): Promise<void> {
         const details = await getDeployDetails(this.context);
         if (!details) { return; }
 
-        await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: `Syncing worktree "${worktree}" with main...`,
-            cancellable: false,
-        }, async () => {
-            try {
-                // Commit any uncommitted changes first
-                try {
-                    await axios.post(
-                        `${details.deployUrl}/agent/worktrees/${worktree}/vcs/commit`,
-                        { message: 'Pre-sync commit' },
-                        { headers: { Authorization: `Bearer ${details.deploySecret}` } },
-                    );
-                } catch { /* nothing to commit */ }
-
-                const result = await axios.post(
-                    `${details.deployUrl}/agent/worktrees/${worktree}/sync`,
-                    {},
-                    {
-                        headers: { Authorization: `Bearer ${details.deploySecret}` },
-                        validateStatus: () => true,
-                    },
-                );
-
-                const data = result.data;
-                if (data.status === 'synced' || data.status === 'success' || data.status === 'already_up_to_date') {
-                    vscode.window.showInformationMessage(`Worktree "${worktree}" synced with main.`);
-                } else if (data.status === 'conflicts') {
-                    const conflictedFiles = (data.conflicted_files || []).join(', ');
-                    vscode.window.showWarningMessage(`Sync has conflicts in: ${conflictedFiles}. Launching Claude to resolve.`);
-                    await this.launchMergeConflictAgent(worktree, data.conflicted_files || []);
-                } else {
-                    vscode.window.showErrorMessage(`Sync failed: ${data.detail || data.message || JSON.stringify(data)}`);
-                }
-            } catch (err: any) {
-                vscode.window.showErrorMessage(`Sync failed: ${err.message}`);
-            }
-        });
-    }
-
-    private async mergeWorktree(worktree: string): Promise<void> {
-        const confirm = await vscode.window.showWarningMessage(
-            `Merge worktree "${worktree}" into main and delete the worktree?`,
-            { modal: true },
-            'Merge & Delete',
-        );
-        if (confirm !== 'Merge & Delete') { return; }
-
-        const details = await getDeployDetails(this.context);
-        if (!details) { return; }
+        const action = deleteAfter ? 'Merge & Delete' : 'Sync';
 
         try {
-            // First commit any uncommitted changes
+            // Commit any uncommitted changes
             try {
                 await axios.post(
                     `${details.deployUrl}/agent/worktrees/${worktree}/vcs/commit`,
-                    { message: 'Pre-merge commit' },
+                    { message: `Pre-${action.toLowerCase()} commit` },
                     { headers: { Authorization: `Bearer ${details.deploySecret}` } },
                 );
-            } catch { /* may fail if nothing to commit — that's fine */ }
+            } catch { /* nothing to commit */ }
 
-            // Start rebase-and-merge
+            // Rebase and fast-forward main
             const result = await axios.post(
                 `${details.deployUrl}/agent/worktrees/${worktree}/rebase-and-merge`,
                 {},
@@ -792,33 +748,45 @@ export class DashboardPanel {
             const data = result.data;
 
             if (data.status === 'merged' || data.status === 'success') {
-                // Merge succeeded — delete worktree automatically
                 const merged_into = data.merged_into || 'main';
-                try {
-                    await axios.delete(
-                        `${details.deployUrl}/worktrees/${worktree}`,
-                        { headers: { Authorization: `Bearer ${details.deploySecret}` } },
-                    );
-                    vscode.window.showInformationMessage(`Worktree "${worktree}" merged into ${merged_into} and deleted.`);
-                } catch (err: any) {
-                    vscode.window.showWarningMessage(`Merged into ${merged_into} but failed to delete worktree: ${err.message}`);
+                if (deleteAfter) {
+                    try {
+                        await axios.delete(
+                            `${details.deployUrl}/worktrees/${worktree}`,
+                            { headers: { Authorization: `Bearer ${details.deploySecret}` } },
+                        );
+                        vscode.window.showInformationMessage(`Worktree "${worktree}" merged into ${merged_into} and deleted.`);
+                    } catch (err: any) {
+                        vscode.window.showWarningMessage(`Merged but failed to delete worktree: ${err.message}`);
+                    }
+                    await this.loadBusinessProcesses();
+                } else {
+                    vscode.window.showInformationMessage(`Worktree "${worktree}" synced with ${merged_into}.`);
                 }
-                await this.loadBusinessProcesses();
             } else if (data.status === 'conflicts') {
-                // Conflicts — launch Claude to resolve
                 const conflictedFiles = (data.conflicted_files || []).join(', ');
-                vscode.window.showWarningMessage(
-                    `Merge has conflicts in: ${conflictedFiles}. Launching Claude to resolve.`,
-                );
+                vscode.window.showWarningMessage(`Conflicts in: ${conflictedFiles}. Launching Claude to resolve.`);
                 await this.launchMergeConflictAgent(worktree, data.conflicted_files || []);
             } else {
-                vscode.window.showErrorMessage(
-                    `Merge failed: ${data.detail || data.message || JSON.stringify(data)}`,
-                );
+                vscode.window.showErrorMessage(`${action} failed: ${data.detail || data.message || JSON.stringify(data)}`);
             }
         } catch (err: any) {
-            vscode.window.showErrorMessage(`Merge failed: ${err.message}`);
+            vscode.window.showErrorMessage(`${action} failed: ${err.message}`);
         }
+    }
+
+    private async syncWorktree(worktree: string): Promise<void> {
+        await this.rebaseAndMerge(worktree, false);
+    }
+
+    private async mergeWorktree(worktree: string): Promise<void> {
+        const confirm = await vscode.window.showWarningMessage(
+            `Merge worktree "${worktree}" into main and delete the worktree?`,
+            { modal: true },
+            'Merge & Delete',
+        );
+        if (confirm !== 'Merge & Delete') { return; }
+        await this.rebaseAndMerge(worktree, true);
     }
 
     private async launchMergeConflictAgent(worktree: string, conflictedFiles: string[]): Promise<void> {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -259,66 +259,10 @@ export class DashboardPanel {
             case 'mergeWorktree':
                 await this.mergeWorktree(msg.worktree);
                 break;
-            case 'openFile': {
-                const dirPath = this.bpMap.get(msg.key);
-                if (dirPath && msg.relPath) {
-                    const filePath = path.join(dirPath, msg.relPath);
-                    if (fs.existsSync(filePath)) {
-                        const doc = await vscode.workspace.openTextDocument(filePath);
-                        await vscode.window.showTextDocument(doc);
-                    }
-                }
-                break;
-            }
-            case 'createFile': {
-                const dir = this.bpMap.get(msg.key);
-                if (dir && msg.name) {
-                    const target = path.join(dir, msg.parentPath || '', msg.name);
-                    fs.mkdirSync(path.dirname(target), { recursive: true });
-                    fs.writeFileSync(target, '', 'utf-8');
-                    this._reloadCurrentKey();
-                }
-                break;
-            }
-            case 'createFolder': {
-                const dir2 = this.bpMap.get(msg.key);
-                if (dir2 && msg.name) {
-                    fs.mkdirSync(path.join(dir2, msg.parentPath || '', msg.name), { recursive: true });
-                    this._reloadCurrentKey();
-                }
-                break;
-            }
-            case 'deleteFile': {
-                const dir3 = this.bpMap.get(msg.key);
-                if (dir3 && msg.relPath) {
-                    const target = path.join(dir3, msg.relPath);
-                    const confirm = await vscode.window.showWarningMessage(
-                        `Delete "${msg.relPath}"?`, { modal: true }, 'Delete'
-                    );
-                    if (confirm === 'Delete') {
-                        fs.rmSync(target, { recursive: true, force: true });
-                        this._reloadCurrentKey();
-                    }
-                }
-                break;
-            }
-            case 'renameFile': {
-                const dir4 = this.bpMap.get(msg.key);
-                if (dir4 && msg.relPath && msg.newName) {
-                    const oldPath = path.join(dir4, msg.relPath);
-                    const newPath = path.join(path.dirname(oldPath), msg.newName);
-                    fs.renameSync(oldPath, newPath);
-                    this._reloadCurrentKey();
-                }
-                break;
-            }
-            case 'uploadFile': {
-                const dir5 = this.bpMap.get(msg.key);
-                if (dir5 && msg.name && msg.data) {
-                    const target = path.join(dir5, msg.parentPath || '', msg.name);
-                    fs.mkdirSync(path.dirname(target), { recursive: true });
-                    fs.writeFileSync(target, Buffer.from(msg.data, 'base64'));
-                    this._reloadCurrentKey();
+            case 'revealInExplorer': {
+                const bpDir = this.bpMap.get(msg.key);
+                if (bpDir) {
+                    vscode.commands.executeCommand('revealInExplorer', vscode.Uri.file(bpDir));
                 }
                 break;
             }
@@ -451,35 +395,10 @@ export class DashboardPanel {
             bpPath = key.substring('workspace:'.length);
         }
 
-        // Files
-        const files = this._scanFiles(dirPath, dirPath);
-
         // Agent sessions for this worktree
         const sessions = worktree ? this._scanSessions(worktree) : [];
 
         this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, files, sessions });
-    }
-
-    private _scanFiles(dir: string, rootDir: string): { name: string; relPath: string; isDirectory: boolean; children?: any[] }[] {
-        const results: { name: string; relPath: string; isDirectory: boolean; children?: any[] }[] = [];
-        try {
-            const entries = fs.readdirSync(dir, { withFileTypes: true });
-            for (const entry of entries) {
-                if (entry.name.startsWith('.') || entry.name === 'node_modules') { continue; }
-                const fullPath = path.join(dir, entry.name);
-                const relPath = path.relative(rootDir, fullPath);
-                if (entry.isDirectory()) {
-                    results.push({ name: entry.name, relPath, isDirectory: true, children: this._scanFiles(fullPath, rootDir) });
-                } else {
-                    results.push({ name: entry.name, relPath, isDirectory: false });
-                }
-            }
-        } catch { /* */ }
-        results.sort((a, b) => {
-            if (a.isDirectory !== b.isDirectory) { return a.isDirectory ? -1 : 1; }
-            return a.name.localeCompare(b.name);
-        });
-        return results;
     }
 
     private _scanSessions(worktree: string): { timestamp: string; userEmail: string; worktree: string; castFile: string; logged: boolean }[] {
@@ -905,6 +824,7 @@ export class DashboardPanel {
         .codicon-debug-restart::before { content: "\\ead2"; }
         .codicon-debug-start::before { content: "\\ead3"; }
         .codicon-link-external::before { content: "\\eb14"; }
+        .codicon-folder-opened::before { content: "\\eaf7"; }
         :root { color-scheme: light dark; font-family: var(--vscode-font-family, sans-serif);
             --status-pass: #3fb950; --status-fail: #f85149; --status-pending: #d29922; --status-retest: #a371f7; --status-proposed: #768390; --border: var(--vscode-editorWidget-border, rgba(128,128,128,0.3)); }
         * { box-sizing: border-box; }
@@ -951,17 +871,6 @@ export class DashboardPanel {
         .auto-card-state.not-deployed { background:var(--status-proposed); color:#fff; }
         .auto-card-actions { display:flex; gap:6px; border-top:1px solid var(--border); padding:10px 16px; }
 
-        /* File tree */
-        .file-tree { font-size:12px; }
-        .file-item { display:flex; align-items:center; gap:6px; padding:3px 4px; border-radius:4px; cursor:pointer; }
-        .file-item:hover { background:var(--vscode-list-hoverBackground, rgba(128,128,128,0.08)); }
-        .file-item-icon { width:16px; text-align:center; flex-shrink:0; }
-        .file-item-name { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-        .file-item-actions { display:none; gap:4px; }
-        .file-item:hover .file-item-actions { display:flex; }
-        .file-item-btn { background:none; border:none; color:var(--vscode-descriptionForeground); cursor:pointer; font-size:11px; padding:0 2px; }
-        .file-item-btn:hover { color:var(--vscode-foreground); }
-        .file-children { margin-left:16px; }
 
         /* Buttons */
         .btn { padding:4px 10px; border:1px solid var(--vscode-button-border, transparent); border-radius:4px; background:var(--vscode-button-secondaryBackground, rgba(128,128,128,0.2)); color:var(--vscode-button-secondaryForeground, var(--vscode-foreground)); cursor:pointer; font-size:11px; }
@@ -1275,50 +1184,16 @@ export class DashboardPanel {
             reqSection.appendChild(addRoot);
             content.appendChild(reqSection);
 
-            // Files
-            if (bpData.files) {
+            // Files — open in VS Code's native file explorer
+            {
                 var filesSection = mkEl('div', 'section');
-                var filesHeader = mkEl('div', '');
-                filesHeader.style.cssText = 'display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;';
-                filesHeader.appendChild(mkEl('div', 'section-title', 'Files'));
-                var fileActions = mkEl('div', '');
-                fileActions.style.cssText = 'display:flex; gap:6px;';
-                var newFileBtn = mkEl('button', 'btn btn-sm', '+ File');
-                newFileBtn.addEventListener('click', function() {
-                    var name = prompt('File name:');
-                    if (name) { vscodeApi.postMessage({ type: 'createFile', key: currentBpKey, name: name, parentPath: '' }); }
+                filesSection.appendChild(mkEl('div', 'section-title', 'Files'));
+                var openExplorerBtn = mkEl('button', 'btn', '');
+                openExplorerBtn.innerHTML = '<span class="codicon codicon-folder-opened"></span> Open in Explorer';
+                openExplorerBtn.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'revealInExplorer', key: currentBpKey });
                 });
-                var newFolderBtn = mkEl('button', 'btn btn-sm', '+ Folder');
-                newFolderBtn.addEventListener('click', function() {
-                    var name = prompt('Folder name:');
-                    if (name) { vscodeApi.postMessage({ type: 'createFolder', key: currentBpKey, name: name, parentPath: '' }); }
-                });
-                var uploadBtn = mkEl('button', 'btn btn-sm', 'Upload');
-                uploadBtn.addEventListener('click', function() {
-                    var input = document.createElement('input');
-                    input.type = 'file';
-                    input.addEventListener('change', function() {
-                        if (input.files && input.files[0]) {
-                            var file = input.files[0];
-                            var reader = new FileReader();
-                            reader.onload = function() {
-                                var base64 = reader.result.toString().split(',')[1];
-                                vscodeApi.postMessage({ type: 'uploadFile', key: currentBpKey, name: file.name, data: base64, parentPath: '' });
-                            };
-                            reader.readAsDataURL(file);
-                        }
-                    });
-                    input.click();
-                });
-                fileActions.appendChild(newFileBtn);
-                fileActions.appendChild(newFolderBtn);
-                fileActions.appendChild(uploadBtn);
-                filesHeader.appendChild(fileActions);
-                filesSection.appendChild(filesHeader);
-
-                var fileTree = mkEl('div', 'file-tree');
-                renderFileTree(bpData.files, fileTree, '');
-                filesSection.appendChild(fileTree);
+                filesSection.appendChild(openExplorerBtn);
                 content.appendChild(filesSection);
             }
 
@@ -1387,56 +1262,6 @@ export class DashboardPanel {
         }
 
         // ---- Requirements tree (same logic as before) ----
-
-        function renderFileTree(files, container, parentPath) {
-            files.forEach(function(f) {
-                var item = mkEl('div', 'file-item');
-                var icon = mkEl('span', 'file-item-icon', f.isDirectory ? '\\u{1F4C1}' : '\\u{1F4C4}');
-                item.appendChild(icon);
-                var nameSpan = mkEl('span', 'file-item-name', f.name);
-                item.appendChild(nameSpan);
-
-                // Inline action buttons
-                var actions = mkEl('div', 'file-item-actions');
-                var renameBtn = mkEl('button', 'file-item-btn', '\\u{270F}');
-                renameBtn.title = 'Rename';
-                renameBtn.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    var newName = prompt('New name:', f.name);
-                    if (newName && newName !== f.name) {
-                        vscodeApi.postMessage({ type: 'renameFile', key: currentBpKey, relPath: f.relPath, newName: newName });
-                    }
-                });
-                actions.appendChild(renameBtn);
-                var deleteBtn = mkEl('button', 'file-item-btn', '\\u{1F5D1}');
-                deleteBtn.title = 'Delete';
-                deleteBtn.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    vscodeApi.postMessage({ type: 'deleteFile', key: currentBpKey, relPath: f.relPath });
-                });
-                actions.appendChild(deleteBtn);
-                item.appendChild(actions);
-
-                if (f.isDirectory) {
-                    var wrapper = mkEl('div', '');
-                    var childContainer = mkEl('div', 'file-children');
-                    childContainer.style.display = 'none';
-                    item.addEventListener('click', function() {
-                        childContainer.style.display = childContainer.style.display === 'none' ? '' : 'none';
-                        icon.textContent = childContainer.style.display === 'none' ? '\\u{1F4C1}' : '\\u{1F4C2}';
-                    });
-                    wrapper.appendChild(item);
-                    if (f.children) { renderFileTree(f.children, childContainer, f.relPath); }
-                    wrapper.appendChild(childContainer);
-                    container.appendChild(wrapper);
-                } else {
-                    item.addEventListener('click', function() {
-                        vscodeApi.postMessage({ type: 'openFile', key: currentBpKey, relPath: f.relPath });
-                    });
-                    container.appendChild(item);
-                }
-            });
-        }
 
         function buildTree(reqs) {
             var map = {}; var roots = [];

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -165,6 +165,9 @@ export class DashboardPanel {
             case 'createAutomation':
                 await this.createAutomation(msg.worktree, msg.bpPath);
                 break;
+            case 'mergeWorktree':
+                await this.mergeWorktree(msg.worktree);
+                break;
         }
     }
 
@@ -371,7 +374,7 @@ export class DashboardPanel {
             }
 
             const userEmail = await getUserEmail(this.context);
-            const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
+            const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
 
             const terminal = vscode.window.createTerminal({
                 name: `Claude: ${worktree}/${bpPath}`,
@@ -420,7 +423,7 @@ export class DashboardPanel {
             }
 
             const userEmail = await getUserEmail(this.context);
-            const cdPath = `/workspace/workspace/worktrees/${worktree}/${bpPath}`;
+            const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
 
             const terminal = vscode.window.createTerminal({
                 name: `Terminal: ${worktree}/${bpPath}`,
@@ -527,6 +530,132 @@ export class DashboardPanel {
         }
 
         vscode.commands.executeCommand('bitswan.openAutomationTemplates', relPath);
+    }
+
+    private async mergeWorktree(worktree: string): Promise<void> {
+        const confirm = await vscode.window.showWarningMessage(
+            `Merge worktree "${worktree}" into the main branch?`,
+            { modal: true },
+            'Merge',
+        );
+        if (confirm !== 'Merge') { return; }
+
+        const { getDeployDetails } = await import('../deploy_details');
+        const details = await getDeployDetails(this.context);
+        if (!details) { return; }
+
+        try {
+            const axios = (await import('axios')).default;
+
+            // First commit any uncommitted changes
+            try {
+                await axios.post(
+                    `${details.deployUrl}/agent/worktrees/${worktree}/vcs/commit`,
+                    { message: 'Pre-merge commit' },
+                    { headers: { Authorization: `Bearer ${details.deploySecret}` } },
+                );
+            } catch { /* may fail if nothing to commit — that's fine */ }
+
+            // Start rebase-and-merge
+            const result = await axios.post(
+                `${details.deployUrl}/agent/worktrees/${worktree}/rebase-and-merge`,
+                {},
+                {
+                    headers: { Authorization: `Bearer ${details.deploySecret}` },
+                    validateStatus: () => true,
+                },
+            );
+
+            const data = result.data;
+
+            if (data.status === 'merged' || data.status === 'success') {
+                // Merge succeeded — ask to delete worktree
+                const merged_into = data.merged_into || 'main';
+                const deleteConfirm = await vscode.window.showInformationMessage(
+                    `Worktree "${worktree}" merged into ${merged_into}. Delete the worktree?`,
+                    'Delete Worktree',
+                    'Keep',
+                );
+                if (deleteConfirm === 'Delete Worktree') {
+                    try {
+                        await axios.delete(
+                            `${details.deployUrl}/worktrees/${worktree}`,
+                            { headers: { Authorization: `Bearer ${details.deploySecret}` } },
+                        );
+                        vscode.window.showInformationMessage(`Worktree "${worktree}" deleted.`);
+                    } catch (err: any) {
+                        vscode.window.showErrorMessage(`Failed to delete worktree: ${err.message}`);
+                    }
+                }
+                await this.loadBusinessProcesses();
+            } else if (data.status === 'conflicts') {
+                // Conflicts — launch Claude to resolve
+                const conflictedFiles = (data.conflicted_files || []).join(', ');
+                vscode.window.showWarningMessage(
+                    `Merge has conflicts in: ${conflictedFiles}. Launching Claude to resolve.`,
+                );
+                await this.launchMergeConflictAgent(worktree, data.conflicted_files || []);
+            } else {
+                vscode.window.showErrorMessage(
+                    `Merge failed: ${data.detail || data.message || JSON.stringify(data)}`,
+                );
+            }
+        } catch (err: any) {
+            vscode.window.showErrorMessage(`Merge failed: ${err.message}`);
+        }
+    }
+
+    private async launchMergeConflictAgent(worktree: string, conflictedFiles: string[]): Promise<void> {
+        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
+        const agentHost = `${workspaceName}-coding-agent`;
+
+        const reachable = await new Promise<boolean>(resolve => {
+            cp.exec(`getent hosts ${agentHost}`, (err) => resolve(!err));
+        });
+
+        if (!reachable) {
+            vscode.window.showErrorMessage('Coding agent container is not running.');
+            return;
+        }
+
+        const userEmail = await getUserEmail(this.context);
+        const wtPath = `/workspace/worktrees/${worktree}`;
+
+        const conflictList = conflictedFiles.map(f => `  - ${f}`).join('\n');
+        const claudePrompt = [
+            `A rebase-and-merge is in progress for worktree "${worktree}" and there are conflicts.`,
+            ``,
+            `Conflicted files:`,
+            conflictList,
+            ``,
+            `Please:`,
+            `1. Open each conflicted file and resolve the conflict markers (<<<<<<<, =======, >>>>>>>)`,
+            `2. After resolving ALL conflicts, run: bitswan-coding-agent vcs rebase-continue`,
+            `3. If more conflicts arise, repeat`,
+            `4. Once the merge is complete, tell the user it's done`,
+        ].join('\\n');
+
+        const terminal = vscode.window.createTerminal({
+            name: `Merge: ${worktree}`,
+            shellPath: '/usr/bin/ssh',
+            shellArgs: [
+                '-i', '/workspace/.ssh/id_ed25519',
+                '-o', 'StrictHostKeyChecking=no',
+                '-o', 'UserKnownHostsFile=/dev/null',
+                '-o', 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE',
+                `agent@${agentHost}`,
+            ],
+            env: {
+                SSH_USER_EMAIL: userEmail,
+                SSH_LOGGED: 'true',
+                SSH_WORKTREE: worktree,
+            },
+        });
+        terminal.show(true);
+
+        setTimeout(() => {
+            terminal.sendText(`cd "${wtPath}" && claude --dangerously-skip-permissions -p "${claudePrompt}"`);
+        }, 2000);
     }
 
     private postMessage(msg: any): void {
@@ -754,6 +883,15 @@ export class DashboardPanel {
                     vscodeApi.postMessage({ type: 'openTerminal', worktree: bpData.worktree, bpPath: bpData.bpPath });
                 });
                 actionsRow.appendChild(termCard);
+
+                if (bpData.worktree) {
+                    var mergeCard = mkEl('div', 'action-card');
+                    mergeCard.innerHTML = '<div class="card-icon">\\u{1F500}</div><div class="card-label">Merge</div><div class="card-desc">Merge worktree into main</div>';
+                    mergeCard.addEventListener('click', function() {
+                        vscodeApi.postMessage({ type: 'mergeWorktree', worktree: bpData.worktree });
+                    });
+                    actionsRow.appendChild(mergeCard);
+                }
 
                 actionsSection.appendChild(actionsRow);
                 content.appendChild(actionsSection);

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -1074,6 +1074,13 @@ export class DashboardPanel {
                 });
                 actionsRow.appendChild(termCard);
 
+                var filesCard = mkEl('div', 'action-card');
+                filesCard.innerHTML = '<div class="card-icon">\\u{1F4C2}</div><div class="card-label">Files</div><div class="card-desc">Browse in Explorer</div>';
+                filesCard.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'revealInExplorer', key: currentBpKey });
+                });
+                actionsRow.appendChild(filesCard);
+
                 if (bpData.worktree) {
                     var mergeCard = mkEl('div', 'action-card');
                     mergeCard.innerHTML = '<div class="card-icon">\\u{1F500}</div><div class="card-label">Merge</div><div class="card-desc">Merge worktree into main</div>';
@@ -1184,18 +1191,6 @@ export class DashboardPanel {
             reqSection.appendChild(addRoot);
             content.appendChild(reqSection);
 
-            // Files — open in VS Code's native file explorer
-            {
-                var filesSection = mkEl('div', 'section');
-                filesSection.appendChild(mkEl('div', 'section-title', 'Files'));
-                var openExplorerBtn = mkEl('button', 'btn', '');
-                openExplorerBtn.innerHTML = '<span class="codicon codicon-folder-opened"></span> Open in Explorer';
-                openExplorerBtn.addEventListener('click', function() {
-                    vscodeApi.postMessage({ type: 'revealInExplorer', key: currentBpKey });
-                });
-                filesSection.appendChild(openExplorerBtn);
-                content.appendChild(filesSection);
-            }
 
             // Agent Sessions
             if (bpData.worktree) {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -398,7 +398,7 @@ export class DashboardPanel {
         // Agent sessions for this worktree
         const sessions = worktree ? this._scanSessions(worktree) : [];
 
-        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, files, sessions });
+        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, sessions });
     }
 
     private _scanSessions(worktree: string): { timestamp: string; userEmail: string; worktree: string; castFile: string; logged: boolean }[] {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -546,13 +546,13 @@ export class DashboardPanel {
     private async openCodingAgentTerminal(worktree: string, bpPath: string): Promise<void> {
         if (worktree) {
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
-            const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
+            const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
             await this.openSSHTerminal(`Claude: ${worktree}/${bpPath}`, worktree, autoCmd);
         } else {
             const cdPath = path.join(WORKSPACE_DIR, bpPath);
             const terminal = vscode.window.createTerminal({ name: `Claude: ${bpPath}`, cwd: cdPath });
             terminal.show(true);
-            terminal.sendText(`mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`);
+            terminal.sendText(`mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`);
         }
     }
 
@@ -727,7 +727,7 @@ export class DashboardPanel {
             `4. Once the merge is complete, tell the user it's done`,
         ].join('\\n');
 
-        const autoCmd = `cd ${wtPath} && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
+        const autoCmd = `cd ${wtPath} && mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
         await this.openSSHTerminal(`Merge: ${worktree}`, worktree, autoCmd);
     }
 

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -511,7 +511,7 @@ export class DashboardPanel {
             const b64 = Buffer.from(autoCmd).toString('base64');
             exportVars += ` SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`;
         }
-        terminal.sendText(`${exportVars} && exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+        terminal.sendText(`${exportVars} && ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}; exit`);
 
         // Track active session
         const termName = terminal.name;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -43,6 +43,14 @@ function serializeRequirementsToml(reqs: Requirement[]): string {
     return toml.stringify(data as any);
 }
 
+interface ActiveSession {
+    worktree: string;
+    userEmail: string;
+    terminalName: string;
+}
+
+const activeSessions: ActiveSession[] = [];
+
 export class DashboardPanel {
     private static currentPanel: DashboardPanel | undefined;
 
@@ -113,6 +121,8 @@ export class DashboardPanel {
         switch (msg.type) {
             case 'ready':
                 await this.loadBusinessProcesses();
+                this.sendActiveSessions();
+                this.postMessage({ type: 'anonMode', enabled: this.context.globalState.get<boolean>('agentAnonMode', false) });
                 break;
             case 'loadBP':
                 await this.loadBPContent(msg.key);
@@ -187,6 +197,11 @@ export class DashboardPanel {
             case 'mergeWorktree':
                 await this.mergeWorktree(msg.worktree);
                 break;
+            case 'focusTerminal': {
+                const t = vscode.window.terminals.find(t => t.name === msg.terminalName);
+                if (t) { t.show(true); }
+                break;
+            }
             case 'toggleAnon': {
                 const current = this.context.globalState.get<boolean>('agentAnonMode', false);
                 await this.context.globalState.update('agentAnonMode', !current);
@@ -441,7 +456,7 @@ export class DashboardPanel {
                 return;
             }
 
-            const userEmail = await getUserEmail(this.context);
+            const userEmail = await getUserEmail(this.context) || 'unknown';
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
 
             const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
@@ -462,6 +477,24 @@ export class DashboardPanel {
                 },
             });
             terminal.show(true);
+
+            // Track active session
+            const termName = terminal.name;
+            activeSessions.push({ worktree, userEmail, terminalName: termName });
+            this.sendActiveSessions();
+
+            // Remove when terminal closes
+            const disposable = vscode.window.onDidCloseTerminal(t => {
+                if (t.name === termName) {
+                    const idx = activeSessions.findIndex(s => s.terminalName === termName);
+                    if (idx >= 0) { activeSessions.splice(idx, 1); }
+                    if (DashboardPanel.currentPanel) {
+                        DashboardPanel.currentPanel.sendActiveSessions();
+                    }
+                    disposable.dispose();
+                }
+            });
+
             setTimeout(() => {
                 terminal.sendText(`cd "${cdPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions`);
             }, 2000);
@@ -491,9 +524,10 @@ export class DashboardPanel {
                 return;
             }
 
-            const userEmail = await getUserEmail(this.context);
+            const userEmail = await getUserEmail(this.context) || 'unknown';
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
 
+            const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const terminal = vscode.window.createTerminal({
                 name: `Terminal: ${worktree}/${bpPath}`,
                 shellPath: '/usr/bin/ssh',
@@ -506,11 +540,26 @@ export class DashboardPanel {
                 ],
                 env: {
                     SSH_USER_EMAIL: userEmail,
-                    SSH_LOGGED: 'false',
+                    SSH_LOGGED: anon ? 'false' : 'true',
                     SSH_WORKTREE: worktree,
                 },
             });
             terminal.show(true);
+
+            const termName = terminal.name;
+            activeSessions.push({ worktree, userEmail, terminalName: termName });
+            this.sendActiveSessions();
+            const disposable = vscode.window.onDidCloseTerminal(t => {
+                if (t.name === termName) {
+                    const idx = activeSessions.findIndex(s => s.terminalName === termName);
+                    if (idx >= 0) { activeSessions.splice(idx, 1); }
+                    if (DashboardPanel.currentPanel) {
+                        DashboardPanel.currentPanel.sendActiveSessions();
+                    }
+                    disposable.dispose();
+                }
+            });
+
             setTimeout(() => {
                 terminal.sendText(`cd "${cdPath}"`);
             }, 2000);
@@ -687,7 +736,7 @@ export class DashboardPanel {
             return;
         }
 
-        const userEmail = await getUserEmail(this.context);
+        const userEmail = await getUserEmail(this.context) || 'unknown';
         const wtPath = `/workspace/worktrees/${worktree}`;
 
         const conflictList = conflictedFiles.map(f => `  - ${f}`).join('\n');
@@ -725,6 +774,10 @@ export class DashboardPanel {
         setTimeout(() => {
             terminal.sendText(`cd "${wtPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions -p "${claudePrompt}"`);
         }, 2000);
+    }
+
+    private sendActiveSessions(): void {
+        this.postMessage({ type: 'activeSessions', sessions: activeSessions });
     }
 
     private postMessage(msg: any): void {
@@ -848,6 +901,32 @@ export class DashboardPanel {
         var currentBpKey = '';
         var bpData = null; // { requirements, automations, readme, worktree, bpPath, sessions }
         var anonMode = false;
+        var activeSessionsList = [];
+
+        function renderActiveSessions(container) {
+            if (!container) { container = document.getElementById('activeSessions'); }
+            if (!container) return;
+            container.innerHTML = '';
+            var filtered = activeSessionsList.filter(function(s) {
+                return !bpData || !bpData.worktree || s.worktree === bpData.worktree;
+            });
+            if (filtered.length === 0) return;
+            filtered.forEach(function(s) {
+                var row = mkEl('div', '');
+                row.style.cssText = 'display:flex; align-items:center; gap:8px; padding:6px 8px; border:1px solid var(--border); border-radius:6px; margin-bottom:4px;';
+                var dot = mkEl('span', '');
+                dot.style.cssText = 'width:8px; height:8px; border-radius:50%; background:var(--status-pass); flex-shrink:0;';
+                row.appendChild(dot);
+                row.appendChild(mkEl('span', '', s.terminalName + ' — ' + s.userEmail));
+                var focusBtn = mkEl('button', 'btn btn-sm', 'Focus');
+                focusBtn.style.marginLeft = 'auto';
+                focusBtn.addEventListener('click', function() {
+                    vscodeApi.postMessage({ type: 'focusTerminal', terminalName: s.terminalName });
+                });
+                row.appendChild(focusBtn);
+                container.appendChild(row);
+            });
+        }
         var mode = 'navigate';
 
         function cycleStatus(s) { var o=['pending','pass','fail','retest','proposed']; return o[(o.indexOf(s)+1)%o.length]; }
@@ -1067,6 +1146,12 @@ export class DashboardPanel {
                 toggleLabel.appendChild(document.createTextNode('Record sessions'));
                 sessHeader.appendChild(toggleLabel);
                 sessSection.appendChild(sessHeader);
+
+                // Active sessions
+                var activeDiv = mkEl('div', '');
+                activeDiv.id = 'activeSessions';
+                renderActiveSessions(activeDiv);
+                sessSection.appendChild(activeDiv);
 
                 // Playback area (hidden by default)
                 var playbackArea = mkEl('div', '');
@@ -1296,9 +1381,13 @@ export class DashboardPanel {
                         renderContent();
                     }
                     break;
+                case 'activeSessions':
+                    activeSessionsList = msg.sessions || [];
+                    renderActiveSessions(null);
+                    break;
                 case 'anonMode':
                     anonMode = msg.enabled;
-                    var cb = document.querySelector('#playbackArea')?.parentElement?.querySelector('input[type=checkbox]');
+                    var cb = document.querySelector('input[type=checkbox]');
                     if (cb) { cb.checked = !anonMode; }
                     break;
                 case 'castData':

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -1092,19 +1092,19 @@ export class DashboardPanel {
                         // Action buttons at bottom
                         var actions = mkEl('div', 'auto-card-actions');
                         if (auto.deploymentId) {
-                            var logsBtn = mkEl('button', 'btn', 'Logs');
+                            var logsBtn = mkEl('button', 'btn', '\u{1F4DC} Logs');
                             logsBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'showLogs', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(logsBtn);
 
-                            var restartBtn = mkEl('button', 'btn', 'Restart');
+                            var restartBtn = mkEl('button', 'btn', '\u{1F504} Restart');
                             restartBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'restartAutomation', deploymentId: auto.deploymentId });
                             });
                             actions.appendChild(restartBtn);
                         } else if (bpData.worktree) {
-                            var startBtn = mkEl('button', 'btn btn-primary', 'Start Live Dev');
+                            var startBtn = mkEl('button', 'btn btn-primary', '\u{25B6}\u{FE0F} Start Live Dev');
                             startBtn.addEventListener('click', function() {
                                 vscodeApi.postMessage({ type: 'startLiveDev', relativePath: auto.relativePath, worktree: bpData.worktree, name: auto.name });
                             });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -513,13 +513,13 @@ export class DashboardPanel {
             const b64 = Buffer.from(autoCmd).toString('base64');
             scriptLines.push(`export SSH_AUTO_CMD="$(echo ${b64} | base64 -d)"`);
         }
-        scriptLines.push(`ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
+        scriptLines.push(`exec ssh -t -i /workspace/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o 'SendEnv=SSH_USER_EMAIL SSH_LOGGED SSH_WORKTREE SSH_AUTO_CMD' agent@${agentHost}`);
         fs.writeFileSync(scriptPath, scriptLines.join('\n') + '\n');
 
         const terminal = vscode.window.createTerminal(name);
         terminal.show(true);
-        // Use source to run the script in the current shell
-        terminal.sendText(`source ${scriptPath}; exit`);
+        // source + exec: the exec replaces bash with ssh, so when ssh exits the terminal closes
+        terminal.sendText(`source ${scriptPath}`);
 
         // Track active session
         const termName = terminal.name;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -814,9 +814,9 @@ export class DashboardPanel {
         @font-face { font-family: codicon; src: url(${this.codiconFontUri}); }
         .codicon { font-family: codicon; font-size: 14px; line-height: 1; display: inline-block; }
         .codicon-output::before { content: "\\eb9d"; }
-        .codicon-debug-restart::before { content: "\\eb4e"; }
-        .codicon-debug-start::before { content: "\\eb49"; }
-        .codicon-link-external::before { content: "\\eb05"; }
+        .codicon-debug-restart::before { content: "\\ead2"; }
+        .codicon-debug-start::before { content: "\\ead3"; }
+        .codicon-link-external::before { content: "\\eb14"; }
         :root { color-scheme: light dark; font-family: var(--vscode-font-family, sans-serif);
             --status-pass: #3fb950; --status-fail: #f85149; --status-pending: #d29922; --status-retest: #a371f7; --status-proposed: #768390; --border: var(--vscode-editorWidget-border, rgba(128,128,128,0.3)); }
         * { box-sizing: border-box; }

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -855,7 +855,7 @@ export class DashboardPanel {
         .auto-card-top.clickable { cursor:pointer; }
         .auto-card-top.clickable:hover { background:var(--vscode-list-hoverBackground, rgba(128,128,128,0.08)); }
         .auto-card-link-icon { position:absolute; top:12px; right:12px; font-size:12px; color:var(--vscode-descriptionForeground); }
-        .auto-card-icon { font-size:28px; margin-bottom:10px; }
+        .auto-card-icon { font-size:28px; margin-bottom:10px; text-align:center; }
         .auto-card-name { font-weight:600; font-size:14px; margin-bottom:4px; }
         .auto-card-state { display:inline-block; font-size:10px; padding:2px 8px; border-radius:10px; text-transform:uppercase; font-weight:600; letter-spacing:0.3px; margin-bottom:8px; }
         .auto-card-state.running { background:var(--status-pass); color:#fff; }

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -473,13 +473,14 @@ export class DashboardPanel {
             activeSessions.push({ worktree, userEmail, terminalName: termName });
             this.sendActiveSessions();
 
-            // Remove when terminal closes
+            // Remove when terminal closes and refresh sessions
             const disposable = vscode.window.onDidCloseTerminal(t => {
                 if (t.name === termName) {
                     const idx = activeSessions.findIndex(s => s.terminalName === termName);
                     if (idx >= 0) { activeSessions.splice(idx, 1); }
                     if (DashboardPanel.currentPanel) {
                         DashboardPanel.currentPanel.sendActiveSessions();
+                        DashboardPanel.currentPanel._reloadCurrentKey();
                     }
                     disposable.dispose();
                 }
@@ -488,6 +489,9 @@ export class DashboardPanel {
             setTimeout(() => {
                 terminal.sendText(`cd "${cdPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions`);
             }, 3000);
+
+            // Refresh sessions after meta.json is created by the agent container
+            setTimeout(() => this._reloadCurrentKey(), 5000);
         } else {
             // Main workspace: local terminal
             const cdPath = path.join(WORKSPACE_DIR, bpPath);
@@ -535,6 +539,7 @@ export class DashboardPanel {
                     if (idx >= 0) { activeSessions.splice(idx, 1); }
                     if (DashboardPanel.currentPanel) {
                         DashboardPanel.currentPanel.sendActiveSessions();
+                        DashboardPanel.currentPanel._reloadCurrentKey();
                     }
                     disposable.dispose();
                 }
@@ -543,6 +548,8 @@ export class DashboardPanel {
             setTimeout(() => {
                 terminal.sendText(`cd "${cdPath}"`);
             }, 2000);
+
+            setTimeout(() => this._reloadCurrentKey(), 5000);
         } else {
             const cdPath = path.join(WORKSPACE_DIR, bpPath);
             const terminal = vscode.window.createTerminal({

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -421,7 +421,7 @@ export class DashboardPanel {
             });
             terminal.show(true);
             setTimeout(() => {
-                terminal.sendText(`cd "${cdPath}" && claude --dangerously-skip-permissions`);
+                terminal.sendText(`cd "${cdPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions`);
             }, 2000);
         } else {
             // Main workspace: local terminal
@@ -431,7 +431,7 @@ export class DashboardPanel {
                 cwd: cdPath,
             });
             terminal.show(true);
-            terminal.sendText('claude --dangerously-skip-permissions');
+            terminal.sendText('mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions');
         }
     }
 
@@ -681,7 +681,7 @@ export class DashboardPanel {
         terminal.show(true);
 
         setTimeout(() => {
-            terminal.sendText(`cd "${wtPath}" && claude --dangerously-skip-permissions -p "${claudePrompt}"`);
+            terminal.sendText(`cd "${wtPath}" && mkdir -p ~/.claude && printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && claude --dangerously-skip-permissions -p "${claudePrompt}"`);
         }, 2000);
     }
 

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -8,6 +8,7 @@ import { getUserEmail } from '../services/user_info';
 const REQUIREMENTS_FILENAME = 'testable-requirements.toml';
 const WORKSPACE_DIR = '/workspace/workspace';
 const WORKTREES_DIR = '/workspace/workspace/worktrees';
+const SESSIONS_DIR = '/workspace/agent-sessions';
 
 interface Requirement {
     id: string;
@@ -56,8 +57,8 @@ export class DashboardPanel {
         this.context = context;
 
         this.panel = vscode.window.createWebviewPanel(
-            'bitswan-dashboard',
-            'Dashboard',
+            'bitswan-workspace',
+            'Workspace',
             vscode.ViewColumn.Active,
             { enableScripts: true, retainContextWhenHidden: true },
         );
@@ -273,7 +274,33 @@ export class DashboardPanel {
             bpPath = key.substring('workspace:'.length);
         }
 
-        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath });
+        // Agent sessions for this worktree
+        const sessions = worktree ? this._scanSessions(worktree) : [];
+
+        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, sessions });
+    }
+
+    private _scanSessions(worktree: string): { timestamp: string; userEmail: string; worktree: string }[] {
+        if (!fs.existsSync(SESSIONS_DIR)) { return []; }
+        const sessions: { timestamp: string; userEmail: string; worktree: string }[] = [];
+        try {
+            const entries = fs.readdirSync(SESSIONS_DIR);
+            for (const e of entries) {
+                if (!e.endsWith('.meta.json')) { continue; }
+                try {
+                    const meta = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, e), 'utf8'));
+                    if ((meta.worktree || '') === worktree) {
+                        sessions.push({
+                            timestamp: meta.timestamp || meta.started_at || '',
+                            userEmail: meta.user_email || meta.userEmail || '',
+                            worktree: meta.worktree || '',
+                        });
+                    }
+                } catch { /* skip */ }
+            }
+        } catch { /* */ }
+        sessions.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        return sessions.slice(0, 20); // last 20
     }
 
     private _findAutomationDirsUnder(bpDir: string): string[] {
@@ -750,7 +777,7 @@ export class DashboardPanel {
     </style>
 </head>
 <body>
-    <div class="header"><h2>Dashboard</h2></div>
+    <div class="header"><h2>Workspace</h2></div>
     <div style="display:flex; align-items:center; padding:0 8px;">
         <span class="tab-label">Worktrees</span>
         <div class="tab-bar" id="tabBar" style="flex:1;"></div>
@@ -971,6 +998,26 @@ export class DashboardPanel {
                 readmeDiv.textContent = bpData.readme;
                 readmeSection.appendChild(readmeDiv);
                 content.appendChild(readmeSection);
+            }
+
+            // Agent Sessions
+            if (bpData.sessions && bpData.sessions.length > 0) {
+                var sessSection = mkEl('div', 'section');
+                sessSection.appendChild(mkEl('div', 'section-title', 'Recent Agent Sessions'));
+                var sessTable = document.createElement('table');
+                sessTable.style.cssText = 'width:100%; border-collapse:collapse; font-size:12px;';
+                sessTable.innerHTML = '<thead><tr style="text-align:left; color:var(--vscode-descriptionForeground);"><th style="padding:4px 8px;">Time</th><th style="padding:4px 8px;">User</th></tr></thead>';
+                var tbody = document.createElement('tbody');
+                bpData.sessions.forEach(function(s) {
+                    var tr = document.createElement('tr');
+                    tr.style.cssText = 'border-top:1px solid var(--border);';
+                    var ts = s.timestamp ? new Date(s.timestamp).toLocaleString() : 'Unknown';
+                    tr.innerHTML = '<td style="padding:4px 8px;">' + ts + '</td><td style="padding:4px 8px;">' + (s.userEmail || 'anonymous') + '</td>';
+                    tbody.appendChild(tr);
+                });
+                sessTable.appendChild(tbody);
+                sessSection.appendChild(sessTable);
+                content.appendChild(sessSection);
             }
 
             // Requirements

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -169,6 +169,24 @@ export class DashboardPanel {
             case 'mergeWorktree':
                 await this.mergeWorktree(msg.worktree);
                 break;
+            case 'toggleAnon': {
+                const current = this.context.globalState.get<boolean>('agentAnonMode', false);
+                await this.context.globalState.update('agentAnonMode', !current);
+                this.postMessage({ type: 'anonMode', enabled: !current });
+                break;
+            }
+            case 'playSession': {
+                if (msg.castFile) {
+                    try {
+                        const fullPath = path.join(SESSIONS_DIR, msg.castFile);
+                        const castContent = fs.readFileSync(fullPath, 'utf8');
+                        this.postMessage({ type: 'castData', castFile: msg.castFile, data: castContent });
+                    } catch (err: any) {
+                        vscode.window.showErrorMessage(`Failed to load recording: ${err.message}`);
+                    }
+                }
+                break;
+            }
         }
     }
 
@@ -280,9 +298,9 @@ export class DashboardPanel {
         this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, sessions });
     }
 
-    private _scanSessions(worktree: string): { timestamp: string; userEmail: string; worktree: string }[] {
+    private _scanSessions(worktree: string): { timestamp: string; userEmail: string; worktree: string; castFile: string; logged: boolean }[] {
         if (!fs.existsSync(SESSIONS_DIR)) { return []; }
-        const sessions: { timestamp: string; userEmail: string; worktree: string }[] = [];
+        const sessions: { timestamp: string; userEmail: string; worktree: string; castFile: string; logged: boolean }[] = [];
         try {
             const entries = fs.readdirSync(SESSIONS_DIR);
             for (const e of entries) {
@@ -290,17 +308,22 @@ export class DashboardPanel {
                 try {
                     const meta = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, e), 'utf8'));
                     if ((meta.worktree || '') === worktree) {
+                        const baseName = e.replace('.meta.json', '');
+                        const castFile = baseName + '.cast';
+                        const hasCast = fs.existsSync(path.join(SESSIONS_DIR, castFile));
                         sessions.push({
                             timestamp: meta.timestamp || meta.started_at || '',
                             userEmail: meta.user_email || meta.userEmail || '',
                             worktree: meta.worktree || '',
+                            castFile: hasCast ? castFile : '',
+                            logged: meta.logged !== false,
                         });
                     }
                 } catch { /* skip */ }
             }
         } catch { /* */ }
         sessions.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-        return sessions.slice(0, 20); // last 20
+        return sessions.slice(0, 20);
     }
 
     private _findAutomationDirsUnder(bpDir: string): string[] {
@@ -403,6 +426,7 @@ export class DashboardPanel {
             const userEmail = await getUserEmail(this.context);
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
 
+            const anon = this.context.globalState.get<boolean>('agentAnonMode', false);
             const terminal = vscode.window.createTerminal({
                 name: `Claude: ${worktree}/${bpPath}`,
                 shellPath: '/usr/bin/ssh',
@@ -415,7 +439,7 @@ export class DashboardPanel {
                 ],
                 env: {
                     SSH_USER_EMAIL: userEmail,
-                    SSH_LOGGED: 'true',
+                    SSH_LOGGED: anon ? 'false' : 'true',
                     SSH_WORKTREE: worktree,
                 },
             });
@@ -743,6 +767,7 @@ export class DashboardPanel {
         /* Buttons */
         .btn { padding:4px 10px; border:1px solid var(--vscode-button-border, transparent); border-radius:4px; background:var(--vscode-button-secondaryBackground, rgba(128,128,128,0.2)); color:var(--vscode-button-secondaryForeground, var(--vscode-foreground)); cursor:pointer; font-size:11px; }
         .btn:hover { opacity:0.85; }
+        .btn-sm { padding:2px 8px; font-size:11px; }
         .btn-primary { background:var(--vscode-button-background); color:var(--vscode-button-foreground); }
         .btn-ghost { background:transparent; color:var(--vscode-descriptionForeground); border:none; }
         .btn-ghost:hover { background:var(--status-fail); color:#fff; }
@@ -800,7 +825,8 @@ export class DashboardPanel {
         var structure = [];
         var currentWsIdx = 0;
         var currentBpKey = '';
-        var bpData = null; // { requirements, automations, readme, worktree, bpPath }
+        var bpData = null; // { requirements, automations, readme, worktree, bpPath, sessions }
+        var anonMode = false;
         var mode = 'navigate';
 
         function cycleStatus(s) { var o=['pending','pass','fail','retest','proposed']; return o[(o.indexOf(s)+1)%o.length]; }
@@ -1001,22 +1027,67 @@ export class DashboardPanel {
             }
 
             // Agent Sessions
-            if (bpData.sessions && bpData.sessions.length > 0) {
+            if (bpData.worktree) {
                 var sessSection = mkEl('div', 'section');
-                sessSection.appendChild(mkEl('div', 'section-title', 'Recent Agent Sessions'));
-                var sessTable = document.createElement('table');
-                sessTable.style.cssText = 'width:100%; border-collapse:collapse; font-size:12px;';
-                sessTable.innerHTML = '<thead><tr style="text-align:left; color:var(--vscode-descriptionForeground);"><th style="padding:4px 8px;">Time</th><th style="padding:4px 8px;">User</th></tr></thead>';
-                var tbody = document.createElement('tbody');
-                bpData.sessions.forEach(function(s) {
-                    var tr = document.createElement('tr');
-                    tr.style.cssText = 'border-top:1px solid var(--border);';
-                    var ts = s.timestamp ? new Date(s.timestamp).toLocaleString() : 'Unknown';
-                    tr.innerHTML = '<td style="padding:4px 8px;">' + ts + '</td><td style="padding:4px 8px;">' + (s.userEmail || 'anonymous') + '</td>';
-                    tbody.appendChild(tr);
+                var sessHeader = mkEl('div', '');
+                sessHeader.style.cssText = 'display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;';
+                sessHeader.appendChild(mkEl('div', 'section-title', 'Agent Sessions'));
+
+                // Recording toggle
+                var toggleLabel = mkEl('label', '');
+                toggleLabel.style.cssText = 'display:flex; align-items:center; gap:6px; font-size:11px; color:var(--vscode-descriptionForeground); cursor:pointer;';
+                var toggleCb = document.createElement('input');
+                toggleCb.type = 'checkbox';
+                toggleCb.checked = !anonMode;
+                toggleCb.addEventListener('change', function() {
+                    vscodeApi.postMessage({ type: 'toggleAnon' });
                 });
-                sessTable.appendChild(tbody);
-                sessSection.appendChild(sessTable);
+                toggleLabel.appendChild(toggleCb);
+                toggleLabel.appendChild(document.createTextNode('Record sessions'));
+                sessHeader.appendChild(toggleLabel);
+                sessSection.appendChild(sessHeader);
+
+                // Playback area (hidden by default)
+                var playbackArea = mkEl('div', '');
+                playbackArea.id = 'playbackArea';
+                playbackArea.style.cssText = 'display:none; margin-bottom:12px; border:1px solid var(--border); border-radius:8px; overflow:hidden; background:#000;';
+                sessSection.appendChild(playbackArea);
+
+                if (bpData.sessions && bpData.sessions.length > 0) {
+                    var sessTable = document.createElement('table');
+                    sessTable.style.cssText = 'width:100%; border-collapse:collapse; font-size:12px;';
+                    sessTable.innerHTML = '<thead><tr style="text-align:left; color:var(--vscode-descriptionForeground);"><th style="padding:4px 8px;">Time</th><th style="padding:4px 8px;">User</th><th style="padding:4px 8px;">Recorded</th><th style="padding:4px 8px;"></th></tr></thead>';
+                    var tbody = document.createElement('tbody');
+                    bpData.sessions.forEach(function(s) {
+                        var tr = document.createElement('tr');
+                        tr.style.cssText = 'border-top:1px solid var(--border);';
+                        var ts = s.timestamp ? new Date(s.timestamp).toLocaleString() : 'Unknown';
+                        var recordedIcon = s.logged ? '\\u{1F534}' : '\\u{26AA}';
+                        var playCell = '';
+                        if (s.castFile) {
+                            playCell = '<button class="btn btn-sm play-btn" data-cast="' + s.castFile + '">\\u25B6 Play</button>';
+                        }
+                        tr.innerHTML = '<td style="padding:4px 8px;">' + ts + '</td><td style="padding:4px 8px;">' + (s.userEmail || 'anonymous') + '</td><td style="padding:4px 8px; text-align:center;">' + recordedIcon + '</td><td style="padding:4px 8px;">' + playCell + '</td>';
+                        tbody.appendChild(tr);
+                    });
+                    sessTable.appendChild(tbody);
+
+                    // Wire up play buttons
+                    sessTable.addEventListener('click', function(e) {
+                        var btn = e.target;
+                        if (btn && btn.classList && btn.classList.contains('play-btn')) {
+                            var castFile = btn.getAttribute('data-cast');
+                            if (castFile) {
+                                vscodeApi.postMessage({ type: 'playSession', castFile: castFile });
+                            }
+                        }
+                    });
+
+                    sessSection.appendChild(sessTable);
+                } else {
+                    sessSection.appendChild(mkEl('div', 'placeholder', 'No sessions yet.'));
+                }
+
                 content.appendChild(sessSection);
             }
 
@@ -1202,6 +1273,18 @@ export class DashboardPanel {
                     if (msg.key === currentBpKey) {
                         bpData = msg;
                         renderContent();
+                    }
+                    break;
+                case 'anonMode':
+                    anonMode = msg.enabled;
+                    var cb = document.querySelector('#playbackArea')?.parentElement?.querySelector('input[type=checkbox]');
+                    if (cb) { cb.checked = !anonMode; }
+                    break;
+                case 'castData':
+                    var area = document.getElementById('playbackArea');
+                    if (area && msg.data) {
+                        area.style.display = 'block';
+                        area.innerHTML = '<pre style="margin:0; padding:12px; max-height:400px; overflow:auto; color:#0f0; font-size:11px; line-height:1.3; white-space:pre-wrap;">' + msg.data.replace(/</g, '&lt;') + '</pre>';
                     }
                     break;
             }

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -650,7 +650,6 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
             const pathParts = source.name.split('/');
             const bp = pathParts.length >= 2 ? sanitizeName(pathParts[0]) : '';
             const bpPfx = bp ? `${bp}-` : '';
-            claimedDeploymentIds.add(`${sanitized}-${bpPfx}live-dev`);
             claimedDeploymentIds.add(`${sanitized}-${bpPfx}dev`);
             claimedDeploymentIds.add(`${sanitized}-${bpPfx}staging`);
             claimedDeploymentIds.add(`${sanitized}-${bp || 'production'}`);
@@ -743,17 +742,15 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
                 stages.push(new StageItem('live-dev', sourceName, null, deploymentId, null, wtSourceUri, serviceNames, wtName));
             }
         } else {
-            // Main mode: standard 4 stages
-            // Deployment ID = {automationName}-{context} where context = {bp}-{stage}
+            // Main mode: 3 stages (live-dev is worktree-only, managed in the Workspace panel)
             const bpPrefix = sanitizedBpName ? `${sanitizedBpName}-` : '';
-            const stageDeploymentIds: Record<'live-dev' | 'dev' | 'staging' | 'production', string> = {
-                'live-dev': `${sanitizedSourceName}-${bpPrefix}live-dev`,
+            const stageDeploymentIds: Record<string, string> = {
                 dev: `${sanitizedSourceName}-${bpPrefix}dev`,
                 staging: `${sanitizedSourceName}-${bpPrefix}staging`,
                 production: `${sanitizedSourceName}-${sanitizedBpName || 'production'}`
             };
 
-            const stagesList: Array<'live-dev' | 'dev' | 'staging' | 'production'> = ['live-dev', 'dev', 'staging', 'production'];
+            const stagesList: Array<'dev' | 'staging' | 'production'> = ['dev', 'staging', 'production'];
 
             for (const stage of stagesList) {
                 const deploymentId = stageDeploymentIds[stage];

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -406,7 +406,9 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
 
         if (element instanceof BusinessProcessItem) {
             console.log(`[DEBUG] getChildren - BusinessProcessItem: "${element.name}"`);
-            const items = this.getAutomationSourcesForBusinessProcess(element.name);
+            const items = (element as any)._idPrefix
+                ? this.getAutomationSourcesAtPath(element.resourceUri.fsPath, element.name)
+                : this.getAutomationSourcesForBusinessProcess(element.name);
             // Namespace IDs for worktree BPs to avoid collisions
             const prefix = (element as any)._idPrefix || '';
             if (prefix) {
@@ -634,6 +636,11 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
         );
 
         return businessProcesses;
+    }
+
+    private getAutomationSourcesAtPath(absolutePath: string, businessProcessName: string): (AutomationSourceItem | SubfolderItem)[] {
+        const allSources = this.getAutomationSourcesInDirectoryRecursive(absolutePath, businessProcessName);
+        return this.buildSubfolderTree(allSources, absolutePath);
     }
 
     private getAutomationSourcesForBusinessProcess(businessProcessName: string): (AutomationSourceItem | SubfolderItem)[] {

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -419,7 +419,12 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
         }
 
         if (element instanceof AutomationSourceItem) {
-            // Show stages (dev/staging/production) for this automation source, followed by file entries and image builds
+            // Worktree automations: no children — actions are inline buttons
+            if ((element as any)._idPrefix) {
+                return [];
+            }
+
+            // Main workspace: show stages, file entries, images
             console.log(`[DEBUG] getChildren - AutomationSourceItem: "${element.name}"`);
             const [stages, fileEntries] = await Promise.all([
                 this.getStagesForSource(element.name),
@@ -446,15 +451,6 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
             }
 
             items.push(imagesSection);
-
-            // Propagate worktree ID prefix to all children
-            const asPrefix = (element as any)._idPrefix || '';
-            if (asPrefix) {
-                for (const item of items) {
-                    if (item.id) { item.id = asPrefix + item.id; }
-                    (item as any)._idPrefix = asPrefix;
-                }
-            }
 
             return items;
         }
@@ -540,6 +536,11 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
         for (const item of items) {
             if (item.id) { item.id = prefix + item.id; }
             (item as any)._idPrefix = prefix;
+            // Worktree automations are leaf nodes — no stages
+            if (item instanceof AutomationSourceItem) {
+                item.collapsibleState = vscode.TreeItemCollapsibleState.None;
+                item.contextValue = 'worktreeAutomation';
+            }
             if (item instanceof SubfolderItem && item.children) {
                 this._prefixTreeItemIds(item.children, prefix);
             }

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -413,7 +413,9 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
                 this._prefixTreeItemIds(items, prefix);
             }
             this._trackAutomationSources(items);
-            return [...items, new CreateAutomationItem(element.name)];
+            const createItem = new CreateAutomationItem(element.name);
+            if (prefix) { createItem.id = prefix + createItem.id; }
+            return [...items, createItem];
         }
 
         if (element instanceof AutomationSourceItem) {
@@ -444,6 +446,15 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
             }
 
             items.push(imagesSection);
+
+            // Propagate worktree ID prefix to all children
+            const asPrefix = (element as any)._idPrefix || '';
+            if (asPrefix) {
+                for (const item of items) {
+                    if (item.id) { item.id = asPrefix + item.id; }
+                    (item as any)._idPrefix = asPrefix;
+                }
+            }
 
             return items;
         }
@@ -528,6 +539,7 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
     private _prefixTreeItemIds(items: readonly vscode.TreeItem[], prefix: string): void {
         for (const item of items) {
             if (item.id) { item.id = prefix + item.id; }
+            (item as any)._idPrefix = prefix;
             if (item instanceof SubfolderItem && item.children) {
                 this._prefixTreeItemIds(item.children, prefix);
             }

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -501,11 +501,14 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
                 return processDirs.map(processDir => {
                     const relativePath = path.relative(wtRoot, processDir);
                     const processConfigPath = path.join(processDir, 'process.toml');
-                    return new BusinessProcessItem(
+                    const item = new BusinessProcessItem(
                         relativePath,
                         vscode.Uri.file(processDir),
                         processConfigPath
                     );
+                    // Namespace the ID to avoid collision with main workspace BPs
+                    item.id = `bp:wt-${element.name}/${relativePath}`;
+                    return item;
                 });
             }
             return [];

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -405,12 +405,14 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
         }
 
         if (element instanceof BusinessProcessItem) {
-            // Show automation sources for this business process
             console.log(`[DEBUG] getChildren - BusinessProcessItem: "${element.name}"`);
             const items = this.getAutomationSourcesForBusinessProcess(element.name);
-            // Track AutomationSourceItems for targeted refresh
+            // Namespace IDs for worktree BPs to avoid collisions
+            const prefix = (element as any)._idPrefix || '';
+            if (prefix) {
+                this._prefixTreeItemIds(items, prefix);
+            }
             this._trackAutomationSources(items);
-            // Add the "+ Create Automation" button at the end
             return [...items, new CreateAutomationItem(element.name)];
         }
 
@@ -498,6 +500,7 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
             const wtRoot = path.join(workspacePath, 'worktrees', element.name);
             if (fs.existsSync(wtRoot)) {
                 const processDirs = this.findDirectoriesWithProcessToml(wtRoot);
+                const wtPrefix = `wt-${element.name}/`;
                 return processDirs.map(processDir => {
                     const relativePath = path.relative(wtRoot, processDir);
                     const processConfigPath = path.join(processDir, 'process.toml');
@@ -506,8 +509,8 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
                         vscode.Uri.file(processDir),
                         processConfigPath
                     );
-                    // Namespace the ID to avoid collision with main workspace BPs
-                    item.id = `bp:wt-${element.name}/${relativePath}`;
+                    item.id = `bp:${wtPrefix}${relativePath}`;
+                    (item as any)._idPrefix = wtPrefix;
                     return item;
                 });
             }
@@ -522,6 +525,15 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
      * Collect AutomationSourceItem instances (including inside SubfolderItems)
      * so that refreshAutomations() can fire targeted change events.
      */
+    private _prefixTreeItemIds(items: readonly vscode.TreeItem[], prefix: string): void {
+        for (const item of items) {
+            if (item.id) { item.id = prefix + item.id; }
+            if (item instanceof SubfolderItem && item.children) {
+                this._prefixTreeItemIds(item.children, prefix);
+            }
+        }
+    }
+
     private _trackAutomationSources(items: readonly UnifiedTreeItem[]): void {
         for (const item of items) {
             if (item instanceof AutomationSourceItem) {

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -269,7 +269,7 @@ export class CreateAutomationItem extends vscode.TreeItem {
  */
 export class WorktreesSectionItem extends vscode.TreeItem {
     constructor() {
-        super('Worktrees', vscode.TreeItemCollapsibleState.Collapsed);
+        super('Worktrees', vscode.TreeItemCollapsibleState.Expanded);
         this.id = 'worktrees-section';
         this.contextValue = 'worktreesSection';
         this.iconPath = new vscode.ThemeIcon('git-branch');
@@ -483,15 +483,30 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
         if (element instanceof WorktreesSectionItem) {
             if (this._worktreesProvider) {
                 const items = await this._worktreesProvider.getChildren();
-                // Add click-to-select command on each worktree item
                 for (const item of items) {
-                    item.command = {
-                        command: 'bitswan.selectWorktree',
-                        title: 'Select Worktree',
-                        arguments: [item.name],
-                    };
+                    item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+                    item.command = undefined;
                 }
                 return items;
+            }
+            return [];
+        }
+
+        if (element instanceof WorktreeItem) {
+            // Show business processes inside this worktree
+            const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '/workspace/workspace';
+            const wtRoot = path.join(workspacePath, 'worktrees', element.name);
+            if (fs.existsSync(wtRoot)) {
+                const processDirs = this.findDirectoriesWithProcessToml(wtRoot);
+                return processDirs.map(processDir => {
+                    const relativePath = path.relative(wtRoot, processDir);
+                    const processConfigPath = path.join(processDir, 'process.toml');
+                    return new BusinessProcessItem(
+                        relativePath,
+                        vscode.Uri.file(processDir),
+                        processConfigPath
+                    );
+                });
             }
             return [];
         }
@@ -532,6 +547,11 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
 
     private getBusinessProcesses(): UnifiedTreeItem[] {
         const businessProcesses: UnifiedTreeItem[] = [];
+
+        // Worktrees at the top (expandable — no mode switching)
+        if (!this._selectedWorktree && this._worktreesProvider) {
+            businessProcesses.push(new WorktreesSectionItem());
+        }
 
         // "Back to Main" button when viewing a worktree
         if (this._selectedWorktree) {
@@ -577,11 +597,6 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
                     }
                 }
             }
-        }
-
-        // Worktrees section (only in main mode)
-        if (!this._selectedWorktree && this._worktreesProvider) {
-            businessProcesses.push(new WorktreesSectionItem());
         }
 
         // Action buttons at the bottom — always show regardless of scan root

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -535,13 +535,41 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
      * so that refreshAutomations() can fire targeted change events.
      */
     private _prefixTreeItemIds(items: readonly vscode.TreeItem[], prefix: string): void {
+        const automations = this.context.globalState.get<any[]>('automations', []);
+        const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '/workspace/workspace';
+
         for (const item of items) {
             if (item.id) { item.id = prefix + item.id; }
             (item as any)._idPrefix = prefix;
-            // Worktree automations are leaf nodes — no stages
+            // Worktree automations are leaf nodes with state info
             if (item instanceof AutomationSourceItem) {
                 item.collapsibleState = vscode.TreeItemCollapsibleState.None;
-                item.contextValue = 'worktreeAutomation';
+
+                // Match against running automations by relative_path
+                const relPath = path.relative(workspacePath, item.resourceUri.fsPath);
+                const match = automations.find(a => {
+                    const aPath = a.relative_path || a.relativePath || '';
+                    return aPath === relPath || aPath.endsWith('/' + relPath);
+                });
+
+                if (match) {
+                    const state = match.state || 'unknown';
+                    const hasUrl = !!(match.automation_url || match.automationUrl);
+                    item.contextValue = `worktreeAutomation,${state}${hasUrl ? ',url' : ''}`;
+                    item.description = state;
+                    // Status icon
+                    if (state === 'running') {
+                        item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+                    } else if (state === 'exited' || state === 'dead') {
+                        item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconFailed'));
+                    } else {
+                        item.iconPath = new vscode.ThemeIcon('circle-outline');
+                    }
+                } else {
+                    item.contextValue = 'worktreeAutomation,notDeployed';
+                    item.description = 'not deployed';
+                    item.iconPath = new vscode.ThemeIcon('circle-outline');
+                }
             }
             if (item instanceof SubfolderItem && item.children) {
                 this._prefixTreeItemIds(item.children, prefix);

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -554,21 +554,28 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
 
                 if (match) {
                     const state = match.state || 'unknown';
+                    const status = match.status || state;
                     const hasUrl = !!(match.automation_url || match.automationUrl);
                     item.contextValue = `worktreeAutomation,${state}${hasUrl ? ',url' : ''}`;
-                    item.description = state;
-                    // Status icon
-                    if (state === 'running') {
-                        item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
-                    } else if (state === 'exited' || state === 'dead') {
-                        item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconFailed'));
-                    } else {
-                        item.iconPath = new vscode.ThemeIcon('circle-outline');
+                    item.description = status;
+                    // Use the same color scheme as AutomationItem
+                    switch (state) {
+                        case 'running':
+                            item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('bitswan.statusIcon.green'));
+                            break;
+                        case 'paused': case 'restarting':
+                            item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('bitswan.statusIcon.orange'));
+                            break;
+                        case 'exited': case 'dead': case 'removing':
+                            item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('bitswan.statusIcon.red'));
+                            break;
+                        default:
+                            item.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('bitswan.statusIcon.gray'));
                     }
                 } else {
                     item.contextValue = 'worktreeAutomation,notDeployed';
                     item.description = 'not deployed';
-                    item.iconPath = new vscode.ThemeIcon('circle-outline');
+                    item.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('bitswan.statusIcon.gray'));
                 }
             }
             if (item instanceof SubfolderItem && item.children) {

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -586,8 +586,7 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
 
         // Action buttons at the bottom — always show regardless of scan root
         businessProcesses.push(
-            new ActionButtonItem('Coding Agents', 'bitswan.openSessionBrowser', 'terminal', 'action:coding-agents'),
-            new ActionButtonItem('Testable Requirements', 'bitswan.openRequirementsEditor', 'checklist', 'action:requirements'),
+            new ActionButtonItem('Workspace', 'bitswan.openRequirementsEditor', 'dashboard', 'action:workspace'),
             new ActionButtonItem('Backups', 'bitswan.openBackups', 'cloud-download', 'action:backups'),
         );
 

--- a/Extension/src/views/worktrees_view.ts
+++ b/Extension/src/views/worktrees_view.ts
@@ -62,31 +62,7 @@ export class WorktreesViewProvider implements vscode.TreeDataProvider<WorktreeIt
             return [];
         }
 
-        // Try gitops API first
-        const details = await getDeployDetails(this.context);
-        if (details) {
-            try {
-                const url = urlJoin(details.deployUrl, 'worktrees/');
-                const response = await axios.get(url, {
-                    headers: { Authorization: `Bearer ${details.deploySecret}` },
-                });
-
-                const worktrees: any[] = response.data;
-                return worktrees.map((wt: any) => new WorktreeItem(
-                    wt.name || 'unknown',
-                    wt.branch || 'unknown',
-                    wt.commit_message || wt.last_commit || wt.lastCommit || '',
-                    wt.has_requirements || wt.hasRequirements || false
-                ));
-            } catch (apiErr: any) {
-                // If 404, fall through to local git
-                if (apiErr?.response?.status !== 404) {
-                    // For other errors (network, auth), still try local fallback
-                }
-            }
-        }
-
-        // Fallback: list worktrees from local filesystem + git
+        // Filesystem is the single source of truth for worktrees
         return this._getWorktreesFromLocal();
     }
 


### PR DESCRIPTION
## Summary
Replaces the Requirements panel with a unified Dashboard that combines everything per business process:

**Layout:**
- Top tabs: Main + one per worktree
- Sub-tabs: One per business process

**Content per BP:**
- **Action cards** (worktree only): Coding Agent (auto-launches Claude) + Terminal
- **Automation cards**: click to open URL, Logs and Restart buttons, status indicators
- **README**: renders README.md if present
- **Requirements**: full CRUD with keyboard navigation (preserved from original)

**Coding Agent terminal:**
- SSHs into the coding agent container
- cds to the BP directory
- Auto-launches `claude --dangerously-skip-permissions`

## Test plan
- [ ] Open Dashboard, verify tabs show Main + worktrees
- [ ] Select a BP, verify automations/requirements/README render
- [ ] Click automation card — opens web URL
- [ ] Click Logs/Restart buttons — work correctly
- [ ] Click Coding Agent — terminal opens, claude launches
- [ ] Click Terminal — plain shell opens in BP dir
- [ ] Requirements CRUD still works (add, edit, delete, cycle status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)