### PR TITLE
Fix build: add skipLibCheck for mermaid d3 type errors

### DIFF
--- a/Extension/tsconfig.json
+++ b/Extension/tsconfig.json
@@ -9,6 +9,7 @@
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */
+		"skipLibCheck": true,
 		"typeRoots": ["./node_modules/@types", "./types"]
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
## Summary
Mermaid's transitive dependency `@types/d3-dispatch` has type definitions incompatible with the project's TypeScript version, causing build failure.

Adding `skipLibCheck: true` to `tsconfig.json` skips type checking of `.d.ts` files in `node_modules` — standard practice for projects with complex dependency trees.

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)