### PR TITLE
Structured matching, disambiguated images, dev mode fix

### DIFF
--- a/Extension/src/utils/automationImageBuilder.ts
+++ b/Extension/src/utils/automationImageBuilder.ts
@@ -628,7 +628,11 @@ export async function ensureAutomationImageReady(
   const normalizedName = sanitizeName(automationName);
 
   // Build fully disambiguated image tag: internal/{workspace}-{bp}-{name}
-  const workspaceName = process.env.BITSWAN_WORKSPACE_NAME || 'workspace-local';
+  const hostname = process.env.HOSTNAME;
+  if (!hostname || !hostname.endsWith('-editor')) {
+    throw new Error(`Cannot determine workspace name: HOSTNAME env var is '${hostname}' (expected '*-editor')`);
+  }
+  const workspaceName = hostname.replace(/-editor$/, '');
   const bpDir = path.basename(path.dirname(automationFolderPath));
   const bpName = sanitizeName(bpDir);
   const fullImageName = `${workspaceName}-${bpName}-${normalizedName}`;

--- a/Extension/src/utils/automationImageBuilder.ts
+++ b/Extension/src/utils/automationImageBuilder.ts
@@ -627,8 +627,14 @@ export async function ensureAutomationImageReady(
   const automationName = path.basename(automationFolderPath);
   const normalizedName = sanitizeName(automationName);
 
+  // Build fully disambiguated image tag: internal/{workspace}-{bp}-{name}
+  const workspaceName = process.env.BITSWAN_WORKSPACE_NAME || 'workspace-local';
+  const bpDir = path.basename(path.dirname(automationFolderPath));
+  const bpName = sanitizeName(bpDir);
+  const fullImageName = `${workspaceName}-${bpName}-${normalizedName}`;
+
   const checksum = calculateGitTreeHash(imageFolder, outputChannel, ignorePatterns);
-  const expectedTag = `internal/${normalizedName}:sha${checksum}`;
+  const expectedTag = `internal/${fullImageName}:sha${checksum}`;
 
   // Get current image value from either config format
   const configState = getCurrentImageValue(automationFolderPath);
@@ -685,7 +691,7 @@ export async function ensureAutomationImageReady(
       details,
       automationFolderPath,
       checksum,
-      normalizedName,
+      fullImageName,
       outputChannel,
       ignorePatterns
     );

--- a/Extension/src/utils/automationImageBuilder.ts
+++ b/Extension/src/utils/automationImageBuilder.ts
@@ -628,11 +628,10 @@ export async function ensureAutomationImageReady(
   const normalizedName = sanitizeName(automationName);
 
   // Build fully disambiguated image tag: internal/{workspace}-{bp}-{name}
-  const hostname = process.env.HOSTNAME;
-  if (!hostname || !hostname.endsWith('-editor')) {
-    throw new Error(`Cannot determine workspace name: HOSTNAME env var is '${hostname}' (expected '*-editor')`);
+  const workspaceName = process.env.BITSWAN_WORKSPACE_NAME;
+  if (!workspaceName) {
+    throw new Error('BITSWAN_WORKSPACE_NAME env var is not set');
   }
-  const workspaceName = hostname.replace(/-editor$/, '');
   const bpDir = path.basename(path.dirname(automationFolderPath));
   const bpName = sanitizeName(bpDir);
   const fullImageName = `${workspaceName}-${bpName}-${normalizedName}`;

--- a/Extension/src/utils/imageMatching.ts
+++ b/Extension/src/utils/imageMatching.ts
@@ -34,7 +34,10 @@ export function isImageMatchingSource(imageName: string, sourceName: string): bo
         return false;
     }
 
-    const sourceFolderName = sourceName.split('/').pop() || sourceName;
+    // sourceName is like "BP/backend" or just "backend"
+    const sourceParts = sourceName.split('/');
+    const sourceFolderName = sourceParts.pop() || sourceName;
+    const bpName = sourceParts.length > 0 ? sourceParts[0] : '';
 
     const normalizedImageName = normalizeName(imageSourcePart);
     const normalizedSourceName = normalizeName(sourceFolderName);
@@ -43,21 +46,23 @@ export function isImageMatchingSource(imageName: string, sourceName: string): bo
         return false;
     }
 
+    // New format: internal/{workspace}-{bp}-{name}:sha{checksum}
+    // Match by checking the image tag ends with -{bp}-{name} or -{name}
+    if (bpName) {
+        const expectedSuffix = normalizeName(`${bpName}-${sourceFolderName}`);
+        if (normalizedImageName.endsWith(expectedSuffix)) {
+            return true;
+        }
+    }
+
+    // Exact match (legacy: internal/{name})
     if (normalizedImageName === normalizedSourceName) {
         return true;
     }
 
-    if (normalizedImageName.includes(normalizedSourceName) || normalizedSourceName.includes(normalizedImageName)) {
+    // Suffix match: image tag ends with the source name (handles workspace prefix)
+    if (normalizedImageName.endsWith(normalizedSourceName)) {
         return true;
-    }
-
-    const imageVariations = generateNameVariations(normalizedImageName);
-    const sourceVariations = generateNameVariations(normalizedSourceName);
-
-    for (const imageVar of imageVariations) {
-        if (sourceVariations.includes(imageVar)) {
-            return true;
-        }
     }
 
     return false;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -927,7 +927,8 @@ export class DashboardPanel {
         .auto-card-state.running { background:var(--status-pass); color:#fff; }
         .auto-card-state.exited, .auto-card-state.dead { background:var(--status-fail); color:#fff; }
         .auto-card-state.not-deployed { background:var(--status-proposed); color:#fff; }
-        .auto-card-actions { display:flex; gap:6px; border-top:1px solid var(--border); padding:10px 16px; }
+        .auto-card-actions { display:flex; gap:4px; flex-wrap:wrap; border-top:1px solid var(--border); padding:8px 12px; }
+        .auto-card-actions .btn { font-size:11px; padding:3px 6px; }
 
 
         /* Buttons */

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -452,7 +452,22 @@ export class DashboardPanel {
         // Agent sessions for this worktree
         const sessions = worktree ? this._scanSessions(worktree) : [];
 
-        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, sessions });
+        // Sync status
+        let synced = false;
+        if (worktree) {
+            try {
+                const details = await getDeployDetails(this.context);
+                if (details) {
+                    const resp = await axios.get(`${details.deployUrl}/worktrees/`, {
+                        headers: { Authorization: `Bearer ${details.deploySecret}` },
+                    });
+                    const wt = (resp.data || []).find((w: any) => w.name === worktree);
+                    synced = wt?.synced === true;
+                }
+            } catch { /* */ }
+        }
+
+        this.postMessage({ type: 'bpContent', key, requirements, automations, readme, worktree, bpPath, sessions, synced });
     }
 
     private _scanSessions(worktree: string): { timestamp: string; userEmail: string; worktree: string; castFile: string; logged: boolean }[] {
@@ -949,6 +964,7 @@ export class DashboardPanel {
         var currentBpKey = '';
         var bpData = null; // { requirements, automations, readme, worktree, bpPath, sessions }
         var anonMode = false;
+        var isSynced = false;
         var activeSessionsList = [];
 
         function renderActiveSessions(container) {
@@ -1018,9 +1034,9 @@ export class DashboardPanel {
 
                 var syncBtn = document.createElement('div');
                 syncBtn.className = 'tab';
-                syncBtn.textContent = '\u{1F504} Sync';
-                syncBtn.title = 'Rebase worktree onto main and fast-forward main';
-                syncBtn.style.cssText = 'font-size:11px; padding:6px 10px;';
+                syncBtn.textContent = isSynced ? '\u{2705} Synced' : '\u{1F504} Sync';
+                syncBtn.title = isSynced ? 'Worktree is synced with main' : 'Rebase worktree onto main and fast-forward main';
+                syncBtn.style.cssText = 'font-size:11px; padding:6px 10px;' + (isSynced ? ' color:var(--status-pass);' : '');
                 syncBtn.addEventListener('click', function() {
                     var wt = getActiveWorktree();
                     if (wt) { vscodeApi.postMessage({ type: 'syncWorktree', worktree: wt }); }
@@ -1176,13 +1192,22 @@ export class DashboardPanel {
                             actions.appendChild(startBtn);
                         }
 
-                        // Deploy to Dev button
+                        // Deploy to Dev button — only works when synced
                         var deployBtn = mkEl('button', 'btn', '');
-                        deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Deploy';
-                        deployBtn.title = 'Deploy to dev stage';
-                        deployBtn.addEventListener('click', function() {
-                            vscodeApi.postMessage({ type: 'deployToDev', name: auto.name, relativePath: auto.relativePath });
-                        });
+                        if (bpData.worktree && !isSynced) {
+                            deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Sync first';
+                            deployBtn.title = 'Worktree must be synced with main before deploying';
+                            deployBtn.style.opacity = '0.5';
+                            deployBtn.addEventListener('click', function() {
+                                vscodeApi.postMessage({ type: 'syncWorktree', worktree: bpData.worktree });
+                            });
+                        } else {
+                            deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Deploy';
+                            deployBtn.title = 'Deploy to dev stage';
+                            deployBtn.addEventListener('click', function() {
+                                vscodeApi.postMessage({ type: 'deployToDev', name: auto.name, relativePath: auto.relativePath });
+                            });
+                        }
                         actions.appendChild(deployBtn);
 
                         // Promotion Manager button
@@ -1488,6 +1513,12 @@ export class DashboardPanel {
                 case 'bpContent':
                     if (msg.key === currentBpKey) {
                         bpData = msg;
+                        var newSynced = !!msg.synced;
+                        if (newSynced !== isSynced) {
+                            isSynced = newSynced;
+                            renderTabs();
+                        }
+                        isSynced = newSynced;
                         renderContent();
                     }
                     break;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -914,7 +914,7 @@ export class DashboardPanel {
         .action-card .card-desc { font-size:11px; color:var(--vscode-descriptionForeground); margin-top:2px; }
 
         /* Automation cards */
-        .auto-cards { display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:12px; }
+        .auto-cards { display:grid; grid-template-columns:repeat(auto-fill, minmax(280px, 1fr)); gap:12px; }
         .auto-card { display:flex; flex-direction:column; border:1px solid var(--border); border-radius:10px; transition: border-color 0.15s, box-shadow 0.15s; overflow:hidden; }
         .auto-card:hover { border-color:var(--vscode-focusBorder, #007acc); box-shadow:0 2px 8px rgba(0,0,0,0.1); }
         .auto-card-top { padding:16px; position:relative; }
@@ -927,8 +927,10 @@ export class DashboardPanel {
         .auto-card-state.running { background:var(--status-pass); color:#fff; }
         .auto-card-state.exited, .auto-card-state.dead { background:var(--status-fail); color:#fff; }
         .auto-card-state.not-deployed { background:var(--status-proposed); color:#fff; }
-        .auto-card-actions { display:flex; gap:4px; flex-wrap:wrap; border-top:1px solid var(--border); padding:8px 12px; }
-        .auto-card-actions .btn { font-size:11px; padding:3px 6px; }
+        .auto-card-actions { display:flex; border-top:1px solid var(--border); }
+        .auto-card-actions .btn { flex:1; border:none; border-radius:0; border-right:1px solid var(--border); padding:8px 4px; font-size:11px; text-align:center; background:transparent; color:var(--vscode-foreground); cursor:pointer; white-space:nowrap; }
+        .auto-card-actions .btn:last-child { border-right:none; }
+        .auto-card-actions .btn:hover { background:var(--vscode-list-hoverBackground, rgba(128,128,128,0.08)); }
 
 
         /* Buttons */

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -276,6 +276,28 @@ export class DashboardPanel {
             case 'mergeWorktree':
                 await this.mergeWorktree(msg.worktree);
                 break;
+            case 'deployToDev': {
+                // Deploy using the same command as the sidebar
+                if (msg.name) {
+                    vscode.commands.executeCommand('bitswan.deployAutomation', {
+                        name: msg.name,
+                        resourceUri: msg.relativePath ? vscode.Uri.file(path.join(this.bpMap.get(this.currentKey) || '', msg.name)) : undefined,
+                        urlSlug: () => msg.name,
+                    });
+                }
+                break;
+            }
+            case 'openPromotionManager': {
+                if (msg.name) {
+                    const bpDir = this.bpMap.get(this.currentKey);
+                    if (bpDir) {
+                        const bpName = path.basename(bpDir);
+                        const sourceName = `${bpName}/${msg.name}`;
+                        vscode.commands.executeCommand('bitswan.openPromotionManager', { automationSourceName: sourceName });
+                    }
+                }
+                break;
+            }
             case 'editReadme': {
                 const bpDir = this.bpMap.get(msg.key);
                 if (bpDir) {
@@ -859,6 +881,8 @@ export class DashboardPanel {
         .codicon-link-external::before { content: "\\eb14"; }
         .codicon-folder-opened::before { content: "\\eaf7"; }
         .codicon-edit::before { content: "\\ea73"; }
+        .codicon-cloud-upload::before { content: "\\eac3"; }
+        .codicon-graph::before { content: "\\eb03"; }
         :root { color-scheme: light dark; font-family: var(--vscode-font-family, sans-serif);
             --status-pass: #3fb950; --status-fail: #f85149; --status-pending: #d29922; --status-retest: #a371f7; --status-proposed: #768390; --border: var(--vscode-editorWidget-border, rgba(128,128,128,0.3)); }
         * { box-sizing: border-box; }
@@ -1042,6 +1066,35 @@ export class DashboardPanel {
                 vscodeApi.postMessage({ type: 'createWorktree' });
             });
             tabBar.appendChild(addWtTab);
+
+            // Sync and Merge & Delete buttons (right-aligned)
+            if (structure.length > 0) {
+                var spacer = document.createElement('div');
+                spacer.style.flex = '1';
+                tabBar.appendChild(spacer);
+
+                var syncBtn = document.createElement('div');
+                syncBtn.className = 'tab';
+                syncBtn.textContent = '\u{1F504} Sync';
+                syncBtn.title = 'Rebase worktree onto main and fast-forward main';
+                syncBtn.style.cssText = 'font-size:11px; padding:6px 10px;';
+                syncBtn.addEventListener('click', function() {
+                    var wt = getActiveWorktree();
+                    if (wt) { vscodeApi.postMessage({ type: 'syncWorktree', worktree: wt }); }
+                });
+                tabBar.appendChild(syncBtn);
+
+                var mergeBtn = document.createElement('div');
+                mergeBtn.className = 'tab';
+                mergeBtn.textContent = '\u{1F500} Merge & Delete';
+                mergeBtn.title = 'Merge into main and delete worktree';
+                mergeBtn.style.cssText = 'font-size:11px; padding:6px 10px;';
+                mergeBtn.addEventListener('click', function() {
+                    var wt = getActiveWorktree();
+                    if (wt) { vscodeApi.postMessage({ type: 'mergeWorktree', worktree: wt }); }
+                });
+                tabBar.appendChild(mergeBtn);
+            }
         }
 
         function getActiveWorktree() {
@@ -1125,22 +1178,6 @@ export class DashboardPanel {
                 });
                 actionsRow.appendChild(filesCard);
 
-                if (bpData.worktree) {
-                    var syncCard = mkEl('div', 'action-card');
-                    syncCard.innerHTML = '<div class="card-icon">\\u{1F504}</div><div class="card-label">Sync</div><div class="card-desc">Rebase onto main branch</div>';
-                    syncCard.addEventListener('click', function() {
-                        vscodeApi.postMessage({ type: 'syncWorktree', worktree: bpData.worktree });
-                    });
-                    actionsRow.appendChild(syncCard);
-
-                    var mergeDeleteCard = mkEl('div', 'action-card');
-                    mergeDeleteCard.innerHTML = '<div class="card-icon">\\u{1F500}</div><div class="card-label">Merge & Delete</div><div class="card-desc">Merge into main and delete worktree</div>';
-                    mergeDeleteCard.addEventListener('click', function() {
-                        vscodeApi.postMessage({ type: 'mergeWorktree', worktree: bpData.worktree });
-                    });
-                    actionsRow.appendChild(mergeDeleteCard);
-                }
-
                 actionsSection.appendChild(actionsRow);
                 content.appendChild(actionsSection);
             }
@@ -1195,6 +1232,25 @@ export class DashboardPanel {
                             });
                             actions.appendChild(startBtn);
                         }
+
+                        // Deploy to Dev button
+                        var deployBtn = mkEl('button', 'btn', '');
+                        deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Deploy';
+                        deployBtn.title = 'Deploy to dev stage';
+                        deployBtn.addEventListener('click', function() {
+                            vscodeApi.postMessage({ type: 'deployToDev', name: auto.name, relativePath: auto.relativePath });
+                        });
+                        actions.appendChild(deployBtn);
+
+                        // Promotion Manager button
+                        var promoteBtn = mkEl('button', 'btn', '');
+                        promoteBtn.innerHTML = '<span class="codicon codicon-graph"></span> Promote';
+                        promoteBtn.title = 'Open Promotion Manager';
+                        promoteBtn.addEventListener('click', function() {
+                            vscodeApi.postMessage({ type: 'openPromotionManager', name: auto.name, relativePath: auto.relativePath });
+                        });
+                        actions.appendChild(promoteBtn);
+
                         card.appendChild(actions);
 
                         autoCards.appendChild(card);

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -766,7 +766,7 @@ export class DashboardPanel {
     }
 
     private async syncWorktree(worktree: string): Promise<void> {
-        const prompt = 'Please sync this worktree with main. First commit any uncommitted changes with: bitswan-coding-agent vcs commit -m "pre-sync commit" then run: bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run: bitswan-coding-agent vcs rebase-continue. Tell me when done.';
+        const prompt = 'IMPORTANT: git is not installed. Use ONLY bitswan-coding-agent commands. Sync this worktree: 1) bitswan-coding-agent vcs commit -m pre-sync-commit 2) bitswan-coding-agent vcs rebase-and-merge 3) If conflicts, resolve and run bitswan-coding-agent vcs rebase-continue. Tell me when done.';
         const autoCmd = [
             `cd /workspace/worktrees/${worktree}`,
             'mkdir -p ~/.claude',
@@ -784,7 +784,7 @@ export class DashboardPanel {
         );
         if (confirm !== 'Merge & Delete') { return; }
 
-        const prompt = 'Please merge this worktree into main. First commit any uncommitted changes with: bitswan-coding-agent vcs commit -m "pre-merge commit" then run: bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run: bitswan-coding-agent vcs rebase-continue. Tell me when the merge is complete.';
+        const prompt = 'IMPORTANT: git is not installed. Use ONLY bitswan-coding-agent commands. Merge this worktree into main: 1) bitswan-coding-agent vcs commit -m pre-merge-commit 2) bitswan-coding-agent vcs rebase-and-merge 3) If conflicts, resolve and run bitswan-coding-agent vcs rebase-continue. Tell me when merge is complete.';
         const autoCmd = [
             `cd /workspace/worktrees/${worktree}`,
             'mkdir -p ~/.claude',

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -766,11 +766,12 @@ export class DashboardPanel {
     }
 
     private async syncWorktree(worktree: string): Promise<void> {
+        const prompt = 'Please sync this worktree with main. First commit any uncommitted changes with: bitswan-coding-agent vcs commit -m "pre-sync commit" then run: bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run: bitswan-coding-agent vcs rebase-continue. Tell me when done.';
         const autoCmd = [
             `cd /workspace/worktrees/${worktree}`,
             'mkdir -p ~/.claude',
-            `printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json`,
-            `exec claude --dangerously-skip-permissions -p "Please sync this worktree with main. Run: bitswan-coding-agent vcs commit -m 'pre-sync commit' then bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run bitswan-coding-agent vcs rebase-continue. Tell me when done."`,
+            `echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json`,
+            `exec claude --dangerously-skip-permissions "${prompt}"`,
         ].join(' && ');
         await this.openSSHTerminal(`Sync: ${worktree}`, worktree, autoCmd);
     }
@@ -783,16 +784,14 @@ export class DashboardPanel {
         );
         if (confirm !== 'Merge & Delete') { return; }
 
+        const prompt = 'Please merge this worktree into main. First commit any uncommitted changes with: bitswan-coding-agent vcs commit -m "pre-merge commit" then run: bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run: bitswan-coding-agent vcs rebase-continue. Tell me when the merge is complete.';
         const autoCmd = [
             `cd /workspace/worktrees/${worktree}`,
             'mkdir -p ~/.claude',
-            `printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json`,
-            `exec claude --dangerously-skip-permissions -p "Please merge this worktree into main and clean up. Run: bitswan-coding-agent vcs commit -m 'pre-merge commit' then bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run bitswan-coding-agent vcs rebase-continue. Tell me when the merge is complete."`,
+            `echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json`,
+            `exec claude --dangerously-skip-permissions "${prompt}"`,
         ].join(' && ');
         await this.openSSHTerminal(`Merge: ${worktree}`, worktree, autoCmd);
-
-        // After the terminal closes, the worktree deletion will be handled
-        // by the user confirming in the terminal session
     }
 
 

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -588,7 +588,11 @@ export class DashboardPanel {
      * Returns the agent hostname, or null if it couldn't be started.
      */
     private async ensureAgentRunning(): Promise<string | null> {
-        const workspaceName = process.env.HOSTNAME?.replace('-editor', '') || 'workspace';
+        const workspaceName = process.env.BITSWAN_WORKSPACE_NAME;
+        if (!workspaceName) {
+            vscode.window.showErrorMessage('BITSWAN_WORKSPACE_NAME env var is not set');
+            return null;
+        }
         const agentHost = `${workspaceName}-coding-agent`;
 
         const isReachable = () => new Promise<boolean>(resolve => {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -765,69 +765,14 @@ export class DashboardPanel {
         vscode.commands.executeCommand('bitswan.openAutomationTemplates', relPath);
     }
 
-    /**
-     * Rebase worktree onto main and fast-forward main.
-     * If deleteAfter is true, deletes the worktree on success.
-     * On conflicts, launches Claude to resolve them.
-     */
-    private async rebaseAndMerge(worktree: string, deleteAfter: boolean): Promise<void> {
-        const details = await getDeployDetails(this.context);
-        if (!details) { return; }
-
-        const action = deleteAfter ? 'Merge & Delete' : 'Sync';
-
-        try {
-            // Commit any uncommitted changes
-            try {
-                await axios.post(
-                    `${details.deployUrl}/agent/worktrees/${worktree}/vcs/commit`,
-                    { message: `Pre-${action.toLowerCase()} commit` },
-                    { headers: { Authorization: `Bearer ${details.deploySecret}` } },
-                );
-            } catch { /* nothing to commit */ }
-
-            // Rebase and fast-forward main
-            const result = await axios.post(
-                `${details.deployUrl}/agent/worktrees/${worktree}/rebase-and-merge`,
-                {},
-                {
-                    headers: { Authorization: `Bearer ${details.deploySecret}` },
-                    validateStatus: () => true,
-                },
-            );
-
-            const data = result.data;
-
-            if (data.status === 'merged' || data.status === 'success') {
-                const merged_into = data.merged_into || 'main';
-                if (deleteAfter) {
-                    try {
-                        await axios.delete(
-                            `${details.deployUrl}/worktrees/${worktree}`,
-                            { headers: { Authorization: `Bearer ${details.deploySecret}` } },
-                        );
-                        vscode.window.showInformationMessage(`Worktree "${worktree}" merged into ${merged_into} and deleted.`);
-                    } catch (err: any) {
-                        vscode.window.showWarningMessage(`Merged but failed to delete worktree: ${err.message}`);
-                    }
-                    await this.loadBusinessProcesses();
-                } else {
-                    vscode.window.showInformationMessage(`Worktree "${worktree}" synced with ${merged_into}.`);
-                }
-            } else if (data.status === 'conflicts') {
-                const conflictedFiles = (data.conflicted_files || []).join(', ');
-                vscode.window.showWarningMessage(`Conflicts in: ${conflictedFiles}. Launching Claude to resolve.`);
-                await this.launchMergeConflictAgent(worktree, data.conflicted_files || []);
-            } else {
-                vscode.window.showErrorMessage(`${action} failed: ${data.detail || data.message || JSON.stringify(data)}`);
-            }
-        } catch (err: any) {
-            vscode.window.showErrorMessage(`${action} failed: ${err.message}`);
-        }
-    }
-
     private async syncWorktree(worktree: string): Promise<void> {
-        await this.rebaseAndMerge(worktree, false);
+        const autoCmd = [
+            `cd /workspace/worktrees/${worktree}`,
+            'mkdir -p ~/.claude',
+            `printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json`,
+            `exec claude --dangerously-skip-permissions -p "Please sync this worktree with main. Run: bitswan-coding-agent vcs commit -m 'pre-sync commit' then bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run bitswan-coding-agent vcs rebase-continue. Tell me when done."`,
+        ].join(' && ');
+        await this.openSSHTerminal(`Sync: ${worktree}`, worktree, autoCmd);
     }
 
     private async mergeWorktree(worktree: string): Promise<void> {
@@ -837,28 +782,20 @@ export class DashboardPanel {
             'Merge & Delete',
         );
         if (confirm !== 'Merge & Delete') { return; }
-        await this.rebaseAndMerge(worktree, true);
-    }
 
-    private async launchMergeConflictAgent(worktree: string, conflictedFiles: string[]): Promise<void> {
-        const wtPath = `/workspace/worktrees/${worktree}`;
-        const conflictList = conflictedFiles.map(f => `  - ${f}`).join('\n');
-        const claudePrompt = [
-            `A rebase-and-merge is in progress for worktree "${worktree}" and there are conflicts.`,
-            ``,
-            `Conflicted files:`,
-            conflictList,
-            ``,
-            `Please:`,
-            `1. Open each conflicted file and resolve the conflict markers (<<<<<<<, =======, >>>>>>>)`,
-            `2. After resolving ALL conflicts, run: bitswan-coding-agent vcs rebase-continue`,
-            `3. If more conflicts arise, repeat`,
-            `4. Once the merge is complete, tell the user it's done`,
-        ].join('\\n');
-
-        const autoCmd = `cd ${wtPath} && mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions -p "${claudePrompt}"`;
+        const autoCmd = [
+            `cd /workspace/worktrees/${worktree}`,
+            'mkdir -p ~/.claude',
+            `printf '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json`,
+            `exec claude --dangerously-skip-permissions -p "Please merge this worktree into main and clean up. Run: bitswan-coding-agent vcs commit -m 'pre-merge commit' then bitswan-coding-agent vcs rebase-and-merge. If there are conflicts, resolve them and run bitswan-coding-agent vcs rebase-continue. Tell me when the merge is complete."`,
+        ].join(' && ');
         await this.openSSHTerminal(`Merge: ${worktree}`, worktree, autoCmd);
+
+        // After the terminal closes, the worktree deletion will be handled
+        // by the user confirming in the terminal session
     }
+
+
 
     private sendActiveSessions(): void {
         this.postMessage({ type: 'activeSessions', sessions: activeSessions });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -7,6 +7,7 @@ import axios from 'axios';
 import { getUserEmail } from '../services/user_info';
 import { getDeployDetails } from '../deploy_details';
 import { AutomationItem } from './automations_view';
+import { AutomationSourceItem } from './unified_business_processes_view';
 
 const REQUIREMENTS_FILENAME = 'testable-requirements.toml';
 const WORKSPACE_DIR = '/workspace/workspace';
@@ -277,13 +278,15 @@ export class DashboardPanel {
                 await this.mergeWorktree(msg.worktree);
                 break;
             case 'deployToDev': {
-                // Deploy using the same command as the sidebar
                 if (msg.name) {
-                    vscode.commands.executeCommand('bitswan.deployAutomation', {
-                        name: msg.name,
-                        resourceUri: msg.relativePath ? vscode.Uri.file(path.join(this.bpMap.get(this.currentKey) || '', msg.name)) : undefined,
-                        urlSlug: () => msg.name,
-                    });
+                    const bpDir = this.bpMap.get(this.currentKey);
+                    if (bpDir) {
+                        const bpName = path.basename(bpDir);
+                        const sourceName = `${bpName}/${msg.name}`;
+                        const autoDir = path.join(bpDir, msg.name);
+                        const item = new AutomationSourceItem(sourceName, vscode.Uri.file(autoDir), bpName);
+                        vscode.commands.executeCommand('bitswan.deployAutomation', item);
+                    }
                 }
                 break;
             }
@@ -293,7 +296,8 @@ export class DashboardPanel {
                     if (bpDir) {
                         const bpName = path.basename(bpDir);
                         const sourceName = `${bpName}/${msg.name}`;
-                        vscode.commands.executeCommand('bitswan.openPromotionManager', { automationSourceName: sourceName });
+                        // Command expects item.name to be "BPName/automationName"
+                        vscode.commands.executeCommand('bitswan.openPromotionManager', { name: sourceName });
                     }
                 }
                 break;

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -279,12 +279,15 @@ export class DashboardPanel {
                 break;
             case 'deployToDev': {
                 if (msg.name) {
+                    // Always deploy from the main workspace path (not worktree)
+                    // so the deployment ID matches the standard format
                     const bpDir = this.bpMap.get(this.currentKey);
                     if (bpDir) {
                         const bpName = path.basename(bpDir);
                         const sourceName = `${bpName}/${msg.name}`;
-                        const autoDir = path.join(bpDir, msg.name);
-                        const item = new AutomationSourceItem(sourceName, vscode.Uri.file(autoDir), bpName);
+                        // Use main workspace path regardless of whether we're in a worktree
+                        const mainAutoDir = path.join(WORKSPACE_DIR, bpName, msg.name);
+                        const item = new AutomationSourceItem(sourceName, vscode.Uri.file(mainAutoDir), bpName);
                         vscode.commands.executeCommand('bitswan.deployAutomation', item);
                     }
                 }

--- a/Extension/src/views/unified_business_processes_view.ts
+++ b/Extension/src/views/unified_business_processes_view.ts
@@ -726,24 +726,17 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
         console.log(`[DEBUG] getOtherAutomationSources - checking ${automations.length} automations for orphaned status`);
         console.log(`[DEBUG] Available automation sources: ${allAutomationSources.map(s => s.name).join(', ')}`);
         
-        // Build a set of deployment IDs that stages actually claim (new format only).
-        // Old-format deployments will fall through to Other since stages can't match them.
-        const claimedDeploymentIds = new Set<string>();
+        // Build a set of known automation names from sources
+        const knownAutomationNames = new Set<string>();
         for (const source of allAutomationSources) {
             const srcName = source.name.split('/').pop() || source.name;
-            const sanitized = sanitizeName(srcName);
-            const pathParts = source.name.split('/');
-            const bp = pathParts.length >= 2 ? sanitizeName(pathParts[0]) : '';
-            const bpPfx = bp ? `${bp}-` : '';
-            claimedDeploymentIds.add(`${sanitized}-${bpPfx}dev`);
-            claimedDeploymentIds.add(`${sanitized}-${bpPfx}staging`);
-            claimedDeploymentIds.add(`${sanitized}-${bp || 'production'}`);
+            knownAutomationNames.add(sanitizeName(srcName));
         }
 
-        // An automation is orphaned if its deployment_id isn't claimed by any stage
+        // An automation is orphaned if its automation_name doesn't match any known source
         const orphanedAutomations = automations.filter(automation => {
-            const depId = automation.deployment_id || automation.deploymentId || '';
-            return !claimedDeploymentIds.has(depId);
+            const autoName = automation.automation_name || automation.automationName || '';
+            return !autoName || !knownAutomationNames.has(autoName);
         });
 
         // Add orphaned automations directly to the result
@@ -828,28 +821,19 @@ export class UnifiedBusinessProcessesViewProvider implements vscode.TreeDataProv
             }
         } else {
             // Main mode: 3 stages (live-dev is worktree-only, managed in the Workspace panel)
-            const bpPrefix = sanitizedBpName ? `${sanitizedBpName}-` : '';
-            const stageDeploymentIds: Record<string, string> = {
-                dev: `${sanitizedSourceName}-${bpPrefix}dev`,
-                staging: `${sanitizedSourceName}-${bpPrefix}staging`,
-                production: `${sanitizedSourceName}-${sanitizedBpName || 'production'}`
-            };
-
             const stagesList: Array<'dev' | 'staging' | 'production'> = ['dev', 'staging', 'production'];
 
             for (const stage of stagesList) {
-                const deploymentId = stageDeploymentIds[stage];
-
+                // Match by structured fields: automation_name + stage
                 const automation = automations.find(a => {
-                    const matches = a.deployment_id === deploymentId || a.deploymentId === deploymentId;
-                    if (!matches && stage === 'production') {
-                        const automationSourceFromPath = a.relativePath?.split('/').pop() || '';
-                        const sanitizedAutomationSource = sanitizeName(automationSourceFromPath);
-                        return sanitizedAutomationSource === sanitizedSourceName &&
-                               (a.stage === '' || a.stage === 'production' || !a.stage);
-                    }
-                    return matches;
+                    const aName = a.automation_name || a.automationName || '';
+                    const aStage = a.stage || 'production';
+                    const normalizedStage = aStage === '' ? 'production' : aStage;
+                    return aName === sanitizedSourceName && normalizedStage === stage;
                 });
+                const deploymentId = automation
+                    ? (automation.deployment_id || automation.deploymentId || '')
+                    : '';
 
                 if (automation) {
                     const automationItem = new AutomationItem(

--- a/update-entrypoint.sh
+++ b/update-entrypoint.sh
@@ -237,6 +237,12 @@ if [ "$BITSWAN_DEV_MODE" = "true" ] && [ -n "$BITSWAN_EXTENSION_DEV_DIR" ] && [ 
     echo "DEV MODE: Setting up extension development environment"
     echo "========================================"
 
+    # Resolve the actual extension root — it may be the repo root with an Extension/ subdir
+    if [ -f "$BITSWAN_EXTENSION_DEV_DIR/Extension/package.json" ] && [ ! -f "$BITSWAN_EXTENSION_DEV_DIR/package.json" ]; then
+        BITSWAN_EXTENSION_DEV_DIR="$BITSWAN_EXTENSION_DEV_DIR/Extension"
+        echo "Resolved extension dev dir to: $BITSWAN_EXTENSION_DEV_DIR"
+    fi
+
     # Extract extension info from the dev directory
     DEV_PACKAGE_JSON="$BITSWAN_EXTENSION_DEV_DIR/package.json"
     if [ -f "$DEV_PACKAGE_JSON" ]; then


### PR DESCRIPTION
## Summary
- Sidebar matches automations by structured `automation_name` + `stage` fields instead of reconstructing deployment IDs from source names
- Image tags now use `internal/{workspace}-{bp}-{name}` format for full disambiguation
- Use `BITSWAN_WORKSPACE_NAME` env var (set by automation server) instead of HOSTNAME hack
- Fix dev mode: resolve `Extension/` subdir when repo root is mounted as dev source

## Test plan
- [ ] Verify sidebar correctly shows running automations under the right source
- [ ] Deploy an automation with custom image and verify tag format is `internal/{workspace}-{bp}-{name}:sha...`
- [ ] Verify dev mode loads correctly when `--editor-dev-source-dir` points to repo root
- [ ] Verify orphaned automations detection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)