### PR TITLE
Give coding agent initial prompt to read context

### DIFF
--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -690,15 +690,18 @@ export class DashboardPanel {
     }
 
     private async openCodingAgentTerminal(worktree: string, bpPath: string): Promise<void> {
+        // Shell-safe initial prompt (no single quotes)
+        const prompt = 'You are a BitSwan coding agent. Start by running: bitswan-coding-agent --help. Then read the README.md in your working directory if it exists. Then run: bitswan-coding-agent requirements list. Then run: bitswan-coding-agent deployments list. After reviewing this context, ask the user what they would like you to work on.';
+
         if (worktree) {
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
-            const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
+            const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions '${prompt}'`;
             await this.openSSHTerminal(`Claude: ${worktree}/${bpPath}`, worktree, autoCmd);
         } else {
             const cdPath = path.join(WORKSPACE_DIR, bpPath);
             const terminal = vscode.window.createTerminal({ name: `Claude: ${bpPath}`, cwd: cdPath });
             terminal.show(true);
-            terminal.sendText(`mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`);
+            terminal.sendText(`mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions '${prompt}'`);
         }
     }
 


### PR DESCRIPTION
## Summary
- When launching Claude from the workspace panel, pass an initial prompt telling it to read `--help`, the README, testable requirements, and deployments, then ask the user what to work on

## Test plan
- [ ] Click coding agent button — Claude starts and reads context before asking what to do

🤖 Generated with [Claude Code](https://claude.com/claude-code)