### PR TITLE
Send automation.toml with live-dev deploy

### DIFF
--- a/Extension/src/commands/deployments.ts
+++ b/Extension/src/commands/deployments.ts
@@ -487,9 +487,14 @@ export async function startLiveDevServerCommand(
             progress.report({ increment: 70, message: "Starting live dev server..." });
 
             // Deploy to live-dev stage.
-            // The server constructs the deployment ID — we send structured data.
+            // Send the raw automation.toml so the server has all config.
+            let automationToml: string | undefined;
+            const tomlPath = path.join(folderPath, 'automation.toml');
+            if (fs.existsSync(tomlPath)) {
+                automationToml = fs.readFileSync(tomlPath, 'utf-8');
+            }
             const deployResult = await startLiveDev(
-                details.deployUrl, details.deploySecret, relativePath, worktreeName
+                details.deployUrl, details.deploySecret, relativePath, worktreeName, automationToml
             );
             const liveDevDeploymentId = deployResult.deployment_id || relativePath;
 

--- a/Extension/src/lib.ts
+++ b/Extension/src/lib.ts
@@ -1266,11 +1266,13 @@ export const startLiveDev = async (
   secret: string,
   relativePath: string,
   worktree?: string,
+  automationToml?: string,
 ): Promise<DeployResponse> => {
   const base = agentBaseUrl.replace(/\/+$/, '');
   const url = `${base}/automations/start-live-dev`;
   const body: Record<string, string> = { relative_path: relativePath };
   if (worktree) { body.worktree = worktree; }
+  if (automationToml) { body.automation_toml = automationToml; }
   const response = await axios.post(url, body, {
     headers: { 'Authorization': `Bearer ${secret}` },
     validateStatus: (status) => status === 200 || status === 202 || status === 409,

--- a/Extension/src/services/sse_client.ts
+++ b/Extension/src/services/sse_client.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import axios from 'axios';
 import { deployState } from './deploy_state';
+import { DashboardPanel } from '../views/dashboard_panel';
 
 /**
  * Stable JSON serialisation: sorts object keys and array elements so that
@@ -116,6 +117,8 @@ export class GitOpsSSEClient {
             }
         } else if (event === 'deploy_progress') {
             deployState.handleDeployProgress(data);
+        } else if (event === 'worktrees') {
+            DashboardPanel.currentPanel?.onWorktreeChanged();
         }
     }
 

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -80,7 +80,7 @@ interface ActiveSession {
 const activeSessions: ActiveSession[] = [];
 
 export class DashboardPanel {
-    private static currentPanel: DashboardPanel | undefined;
+    public static currentPanel: DashboardPanel | undefined;
 
     private readonly panel: vscode.WebviewPanel;
     private readonly context: vscode.ExtensionContext;
@@ -155,12 +155,8 @@ export class DashboardPanel {
         readmeWatcher.onDidChange(() => this._reloadCurrentKey());
         context.subscriptions.push(readmeWatcher);
 
-        // Poll for sync status changes (git commits can't be detected by file watchers)
-        const syncPollInterval = setInterval(() => this._reloadCurrentKey(), 10000);
-
         this.panel.onDidDispose(() => {
             this.disposed = true;
-            clearInterval(syncPollInterval);
             if (this.fileWatcher) { this.fileWatcher.dispose(); }
             DashboardPanel.currentPanel = undefined;
         });
@@ -583,6 +579,11 @@ export class DashboardPanel {
         if (!this.disposed && this.currentKey) {
             this.loadBPContent(this.currentKey);
         }
+    }
+
+    /** Called by SSE client when worktree sync status changes. */
+    public onWorktreeChanged(): void {
+        this._reloadCurrentKey();
     }
 
     // ---- Terminals ----

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -108,7 +108,7 @@ export class DashboardPanel {
 
         this.panel = vscode.window.createWebviewPanel(
             'bitswan-workspace',
-            'Workspace',
+            'Bitswan Workspace',
             vscode.ViewColumn.Active,
             {
                 enableScripts: true,
@@ -116,6 +116,7 @@ export class DashboardPanel {
                 localResourceRoots: [asciinemaDir, codiconDir, markedDir, mermaidDir],
             },
         );
+        this.panel.iconPath = vscode.Uri.file(path.join(context.extensionPath, 'resources', 'bitswan-logo.svg'));
 
         this.playerJsUri = this.panel.webview.asWebviewUri(vscode.Uri.file(
             path.join(context.extensionPath, 'node_modules', 'asciinema-player', 'dist', 'bundle', 'asciinema-player.min.js')

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -155,8 +155,12 @@ export class DashboardPanel {
         readmeWatcher.onDidChange(() => this._reloadCurrentKey());
         context.subscriptions.push(readmeWatcher);
 
+        // Poll for sync status changes (git commits can't be detected by file watchers)
+        const syncPollInterval = setInterval(() => this._reloadCurrentKey(), 10000);
+
         this.panel.onDidDispose(() => {
             this.disposed = true;
+            clearInterval(syncPollInterval);
             if (this.fileWatcher) { this.fileWatcher.dispose(); }
             DashboardPanel.currentPanel = undefined;
         });

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -1211,7 +1211,7 @@ export class DashboardPanel {
                         // Deploy to Dev button — only works when synced
                         var deployBtn = mkEl('button', 'btn', '');
                         if (bpData.worktree && !isSynced) {
-                            deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Deploy (sync first)';
+                            deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Deploy<br><small>sync first</small>';
                             deployBtn.title = 'Worktree must be synced with main before deploying';
                             deployBtn.style.opacity = '0.5';
                             deployBtn.addEventListener('click', function() {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -6,6 +6,7 @@ import * as toml from '@iarna/toml';
 import axios from 'axios';
 import { getUserEmail } from '../services/user_info';
 import { getDeployDetails } from '../deploy_details';
+import { startLiveDevServerCommand } from '../commands/deployments';
 import { AutomationItem } from './automations_view';
 import { AutomationSourceItem } from './unified_business_processes_view';
 
@@ -198,22 +199,9 @@ export class DashboardPanel {
                 break;
             case 'startLiveDev': {
                 if (msg.relativePath && msg.worktree) {
-                    try {
-                        const { startLiveDev } = require('../lib');
-                        const details = await getDeployDetails(this.context);
-                        if (details) {
-                            const result = await startLiveDev(details.deployUrl, details.deploySecret, msg.relativePath, msg.worktree);
-                            if (result.success) {
-                                vscode.window.showInformationMessage(`Live dev started for ${msg.name || 'automation'}`);
-                                // Refresh after deploy completes
-                                setTimeout(() => this._reloadCurrentKey(), 5000);
-                            } else {
-                                vscode.window.showErrorMessage('Failed to start live dev');
-                            }
-                        }
-                    } catch (err: any) {
-                        vscode.window.showErrorMessage(`Failed to start live dev: ${err.message}`);
-                    }
+                    const folderPath = path.join(WORKSPACE_DIR, msg.relativePath);
+                    await startLiveDevServerCommand(this.context, folderPath, undefined, msg.worktree);
+                    this._reloadCurrentKey();
                 }
                 break;
             }

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -690,15 +690,18 @@ export class DashboardPanel {
     }
 
     private async openCodingAgentTerminal(worktree: string, bpPath: string): Promise<void> {
+        // Shell-safe initial prompt (no single quotes)
+        const prompt = 'You are a BitSwan coding agent. Start by running: bitswan-coding-agent --help. Then read the README.md in your working directory if it exists. Then run: bitswan-coding-agent requirements list. Then run: bitswan-coding-agent deployments list. After reviewing this context, ask the user what they would like you to work on.';
+
         if (worktree) {
             const cdPath = `/workspace/worktrees/${worktree}/${bpPath}`;
-            const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`;
+            const autoCmd = `cd ${cdPath} && mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions '${prompt}'`;
             await this.openSSHTerminal(`Claude: ${worktree}/${bpPath}`, worktree, autoCmd);
         } else {
             const cdPath = path.join(WORKSPACE_DIR, bpPath);
             const terminal = vscode.window.createTerminal({ name: `Claude: ${bpPath}`, cwd: cdPath });
             terminal.show(true);
-            terminal.sendText(`mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions`);
+            terminal.sendText(`mkdir -p ~/.claude && echo '{"skipDangerousModePermissionPrompt":true}' > ~/.claude/settings.json && exec claude --dangerously-skip-permissions '${prompt}'`);
         }
     }
 

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -1211,7 +1211,7 @@ export class DashboardPanel {
                         // Deploy to Dev button — only works when synced
                         var deployBtn = mkEl('button', 'btn', '');
                         if (bpData.worktree && !isSynced) {
-                            deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Sync first';
+                            deployBtn.innerHTML = '<span class="codicon codicon-cloud-upload"></span> Deploy (sync first)';
                             deployBtn.title = 'Worktree must be synced with main before deploying';
                             deployBtn.style.opacity = '0.5';
                             deployBtn.addEventListener('click', function() {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -406,6 +406,17 @@ export class DashboardPanel {
             try { readme = fs.readFileSync(readmePath, 'utf-8'); } catch { /* */ }
         }
 
+        // Parse key to get worktree and bpPath
+        let worktree = '';
+        let bpPath = '';
+        if (key.startsWith('worktree:')) {
+            const parts = key.split(':');
+            worktree = parts[1] || '';
+            bpPath = parts.slice(2).join(':');
+        } else if (key.startsWith('workspace:')) {
+            bpPath = key.substring('workspace:'.length);
+        }
+
         // Automations — match by relative_path
         const allAutomations = this.context.globalState.get<any[]>('automations', []);
         const automations: AutomationInfo[] = [];
@@ -445,17 +456,6 @@ export class DashboardPanel {
                 relativePath: relFromWorkspace,
                 icon: inferAutomationIcon(autoDir),
             });
-        }
-
-        // Parse key to get worktree and bpPath
-        let worktree = '';
-        let bpPath = '';
-        if (key.startsWith('worktree:')) {
-            const parts = key.split(':');
-            worktree = parts[1] || '';
-            bpPath = parts.slice(2).join(':');
-        } else if (key.startsWith('workspace:')) {
-            bpPath = key.substring('workspace:'.length);
         }
 
         // Agent sessions for this worktree

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -416,9 +416,16 @@ export class DashboardPanel {
             const autoName = path.basename(autoDir);
             const relFromWorkspace = path.relative(WORKSPACE_DIR, autoDir);
             // Find matching automation from global state
+            // In worktree mode, only match live-dev deployments for this worktree
             const match = allAutomations?.find(a => {
                 const aPath = a.relative_path || a.relativePath || '';
-                return aPath === relFromWorkspace || aPath.endsWith('/' + relFromWorkspace);
+                const pathMatch = aPath === relFromWorkspace || aPath.endsWith('/' + relFromWorkspace);
+                if (!pathMatch) { return false; }
+                if (worktree) {
+                    const aStage = a.stage || '';
+                    return aStage === 'live-dev';
+                }
+                return true;
             });
             let state = 'not deployed';
             if (match) {

--- a/Extension/src/views/dashboard_panel.ts
+++ b/Extension/src/views/dashboard_panel.ts
@@ -432,10 +432,20 @@ export class DashboardPanel {
                 const aPath = a.relative_path || a.relativePath || '';
                 return aPath === relFromWorkspace || aPath.endsWith('/' + relFromWorkspace);
             });
+            let state = 'not deployed';
+            if (match) {
+                const dockerState = match.state || '';
+                if (dockerState === 'running') { state = 'running'; }
+                else if (dockerState === 'exited' || dockerState === 'dead') { state = 'stopped'; }
+                else if (dockerState === 'restarting') { state = 'restarting'; }
+                else if (dockerState === 'created' || dockerState === 'paused') { state = dockerState; }
+                else if (dockerState) { state = dockerState; }
+                else { state = 'starting'; }
+            }
             automations.push({
                 name: autoName,
                 deploymentId: match ? (match.deployment_id || match.deploymentId || '') : '',
-                state: match ? (match.state || 'not deployed') : 'not deployed',
+                state,
                 url: match ? (match.automation_url || match.automationUrl || '') : '',
                 relativePath: relFromWorkspace,
                 icon: inferAutomationIcon(autoDir),


### PR DESCRIPTION
## Summary
- Read raw `automation.toml` and send it with the `startLiveDev` request
- Server parses it and uses all config (services, secrets, etc.)

## Test plan
- [ ] Deploy live-dev — postgres/minio start if declared in automation.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)