### PR TITLE
Remove dead automation config sending from editor

### DIFF
--- a/Extension/src/lib.ts
+++ b/Extension/src/lib.ts
@@ -1318,35 +1318,9 @@ export const promoteAutomation = async (
   if (context) {
     form.append('context', context);
   }
-  // Send automation config for live-dev (so server doesn't need to read from filesystem)
-  if (automationConfig) {
-    if (automationConfig.image) {
-      form.append('image', automationConfig.image);
-    }
-    if (automationConfig.expose !== undefined) {
-      form.append('expose', automationConfig.expose.toString());
-    }
-    if (automationConfig.exposeTo && automationConfig.exposeTo.length > 0) {
-      form.append('expose_to', JSON.stringify(automationConfig.exposeTo));
-    }
-    if (automationConfig.port !== undefined) {
-      form.append('port', automationConfig.port.toString());
-    }
-    if (automationConfig.mountPath) {
-      form.append('mount_path', automationConfig.mountPath);
-    }
-    if (automationConfig.secretGroups && automationConfig.secretGroups.length > 0) {
-      form.append('secret_groups', automationConfig.secretGroups.join(','));
-    }
-    if (automationConfig.automationId) {
-      form.append('automation_id', automationConfig.automationId);
-    }
-    if (automationConfig.auth !== undefined) {
-      form.append('auth', automationConfig.auth.toString());
-    }
-    if (automationConfig.services) {
-      form.append('services', JSON.stringify(automationConfig.services));
-    }
+  // Send services so the server can auto-enable infra (postgres, minio, etc.)
+  if (automationConfig?.services) {
+    form.append('services', JSON.stringify(automationConfig.services));
   }
 
   const response = await axios.post(deployUrl, form, {


### PR DESCRIPTION
## Summary
- Remove dead config field sending from `promoteAutomation` (image, expose, port, etc.)
- Server now reads all config from automation.toml via `resolve_automation_config()`
- Only `services` is still sent for infra auto-enable

## Test plan
- [ ] Deploy from sidebar still works
- [ ] Live-dev from dashboard still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)