### PR TITLE
Fix English typos in Extension source files

### DIFF
--- a/Extension/src/commands/deployments.ts
+++ b/Extension/src/commands/deployments.ts
@@ -313,7 +313,7 @@ export async function deployCommandAbstract(
 
                 // Tar the pipeline config folder and buffer it before posting.
                 // archiver's Transform stream has no knownLength, so handing it
-                // to form-data directly produces an unparseable multipart body
+                // to form-data directly produces an unparsable multipart body
                 // (server reports body.file missing).
                 const stream = createStreamingTarFromDir(folderPath, outputChannel);
                 const buffer = await bufferStreamToBuffer(stream);
@@ -329,8 +329,8 @@ export async function deployCommandAbstract(
                 const success = await deploy(deployUrl, form, details.deploySecret, outputChannel);
 
                 if (success) {
-                    progress.report({ increment: 100, message: "Succesfully uploaded "+messages[itemSet]["item"]+" to GitOps" });
-                    vscode.window.showInformationMessage("Succesfully uploaded "+messages[itemSet]["item"]+" to GitOps");
+                    progress.report({ increment: 100, message: "Successfully uploaded "+messages[itemSet]["item"]+" to GitOps" });
+                    vscode.window.showInformationMessage("Successfully uploaded "+messages[itemSet]["item"]+" to GitOps");
                     
                     // Refresh image views if this was an image build
                     if (itemSet === "images" && unifiedImagesProvider && orphanedImagesProvider) {

--- a/Extension/src/lib.ts
+++ b/Extension/src/lib.ts
@@ -815,7 +815,7 @@ export const createStreamingTarFromDir = (
  *
  * archiver returns a Transform stream with no `knownLength`, so when it's
  * passed straight to `form-data.append`, form-data can't compute a
- * Content-Length and the resulting multipart body is unparseable on the
+ * Content-Length and the resulting multipart body is unparsable on the
  * server (every form field shows up "missing"). Buffering before append
  * sidesteps that — fine for image archives which are small (Dockerfile +
  * entrypoint + a handful of config files).

--- a/Extension/src/utils/automationImageBuilder.ts
+++ b/Extension/src/utils/automationImageBuilder.ts
@@ -533,7 +533,7 @@ async function startImageBuild(
   const stream = createStreamingTarFromDir(imageDir, outputChannel, ignorePatterns);
   // Buffer the archive so form-data can compute Content-Length. archiver's
   // Transform stream has no knownLength, which makes the multipart body
-  // unparseable on the server (FastAPI reports body.file/body.checksum
+  // unparsable on the server (FastAPI reports body.file/body.checksum
   // missing). See bufferStreamToBuffer for context.
   const buffer = await bufferStreamToBuffer(stream);
 


### PR DESCRIPTION
unparseable→unparsable (3 occurrences), Succesfully→Successfully (2 occurrences).